### PR TITLE
feat: add OPPO compatibility mode for Live Photo metadata

### DIFF
--- a/src/livemaker.vala
+++ b/src/livemaker.vala
@@ -165,11 +165,20 @@ public abstract class LivePhotoConv.LiveMaker : Object {
 
         // OPPO needs specific tags
         if (this.oppo_compatible) {
+            Reporter.info_puts ("OppoCompatibility", "Setting extra metadata for OPPO compatibility.");
             GExiv2.Metadata.try_register_xmp_namespace ("http://ns.oplus.com/photos/1.0/camera/", "OpCamera");
             this.metadata.try_set_tag_string ("Xmp.OpCamera.MotionPhotoPrimaryPresentationTimestampUs", presentation_timestamp_us_to_write);
             this.metadata.try_set_tag_string ("Xmp.OpCamera.MotionPhotoOwner", "oplus");
             this.metadata.try_set_tag_string ("Xmp.OpCamera.OLivePhotoVersion", "2");
             this.metadata.try_set_tag_string ("Xmp.OpCamera.VideoLength", video_size.to_string ());
+            // oplus_11534368 is the constant used by OPPO Find X8s+, reported to work. Use it here for compatibility.
+            string? user_comment = null;
+            try {
+                user_comment = this.metadata.try_get_tag_string ("Exif.Photo.UserComment");
+            } catch {}
+            if (user_comment == null || (!user_comment.has_prefix ("oplus_"))) {
+                this.metadata.try_set_tag_string ("Exif.Photo.UserComment", "oplus_11534368");
+            }
         }
 
         try {

--- a/src/livemaker.vala
+++ b/src/livemaker.vala
@@ -45,7 +45,12 @@ public abstract class LivePhotoConv.LiveMaker : Object {
         set;
         default = true;
     }
-    
+    public bool oppo_compatible {
+        get;
+        set;
+        default = false;
+    }
+
     /**
      * Creates a new LiveMaker instance.
      *
@@ -157,6 +162,15 @@ public abstract class LivePhotoConv.LiveMaker : Object {
         this.metadata.try_set_tag_string ("Xmp.Container.Directory[2]/Container:Item/Item:Mime", "video/mp4");
         this.metadata.try_set_tag_string ("Xmp.Container.Directory[2]/Container:Item/Item:Semantic", "MotionPhoto");
         this.metadata.try_set_tag_string ("Xmp.Container.Directory[2]/Container:Item/Item:Length", video_size.to_string ());
+
+        // OPPO needs specific tags
+        if (this.oppo_compatible) {
+            GExiv2.Metadata.try_register_xmp_namespace ("http://ns.oplus.com/photos/1.0/camera/", "OpCamera");
+            this.metadata.try_set_tag_string ("Xmp.OpCamera.MotionPhotoPrimaryPresentationTimestampUs", presentation_timestamp_us_to_write);
+            this.metadata.try_set_tag_string ("Xmp.OpCamera.MotionPhotoOwner", "oplus");
+            this.metadata.try_set_tag_string ("Xmp.OpCamera.OLivePhotoVersion", "2");
+            this.metadata.try_set_tag_string ("Xmp.OpCamera.VideoLength", video_size.to_string ());
+        }
 
         try {
             this.metadata.save_file (this.dest);

--- a/src/livephoto.vala
+++ b/src/livephoto.vala
@@ -57,6 +57,11 @@ public abstract class LivePhotoConv.LivePhoto : Object {
         set;
         default = FileCreateFlags.REPLACE_DESTINATION;
     }
+    public bool oppo_compatible {
+        get;
+        set;
+        default = false;
+    }
 
     /**
      * Creates a new instance of the LivePhoto class.
@@ -388,6 +393,15 @@ public abstract class LivePhotoConv.LivePhoto : Object {
         this.xmp_map.insert ("Xmp.Container.Directory[2]/Item:Mime", "video/mp4");
         this.xmp_map.insert ("Xmp.Container.Directory[2]/Item:Semantic", "MotionPhoto");
         this.xmp_map.insert ("Xmp.Container.Directory[2]/Item:Length", offset_string); // offset_string is reverse_offset, i.e., video_size
+
+        // OPPO needs specific tags
+        if (this.oppo_compatible) {
+            GExiv2.Metadata.try_register_xmp_namespace ("http://ns.oplus.com/photos/1.0/camera/", "OpCamera");
+            this.xmp_map.insert ("Xmp.OpCamera.MotionPhotoPrimaryPresentationTimestampUs", presentation_timestamp_us_to_write);
+            this.xmp_map.insert ("Xmp.OpCamera.MotionPhotoOwner", "oplus");
+            this.xmp_map.insert ("Xmp.OpCamera.OLivePhotoVersion", "2");
+            this.xmp_map.insert ("Xmp.OpCamera.VideoLength", offset_string);
+        }
 
         // Restore the XMP metadata for the live photo
         Error? metadata_error = null;

--- a/src/livephoto.vala
+++ b/src/livephoto.vala
@@ -40,7 +40,7 @@ public abstract class LivePhotoConv.LivePhoto : Object {
     protected GExiv2.Metadata metadata;
     protected string dest_dir;
     protected int64 video_offset;
-    protected Tree<string?, string?> xmp_map;
+    protected Tree<string?, string?> livemeta_map;
 
     public bool make_backup {
         get;
@@ -83,10 +83,10 @@ public abstract class LivePhotoConv.LivePhoto : Object {
         this.metadata.open_path (filename);
 
         // Copy the XMP metadata to the map
-        this.xmp_map = new Tree<string?, string?> ((a, b) => {return strcmp (a, b);});
+        this.livemeta_map = new Tree<string?, string?> ((a, b) => {return strcmp (a, b);});
         foreach (unowned var tag in this.metadata.get_xmp_tags ()) {
             try {
-                this.xmp_map.insert (tag, this.metadata.try_get_tag_string (tag));
+                this.livemeta_map.insert (tag, this.metadata.try_get_tag_string (tag));
             } catch (Error e) {
                 Reporter.warning ("XMPWarning", "Cannot get the value of the XMP tag %s: %s", tag, e.message);
             }
@@ -133,10 +133,10 @@ public abstract class LivePhotoConv.LivePhoto : Object {
     */
     inline int64 get_video_offset () throws Error {
         // Get the offset of the video data from the XMP metadata
-        var tag_value = this.xmp_map.lookup ("Xmp.Container.Directory[2]/Container:Item/Item:Length");
+        var tag_value = this.livemeta_map.lookup ("Xmp.Container.Directory[2]/Container:Item/Item:Length");
         if (tag_value == null) {
             // Fallback to the old standard
-            tag_value = this.xmp_map.lookup ("Xmp.GCamera.MicroVideoOffset");
+            tag_value = this.livemeta_map.lookup ("Xmp.GCamera.MicroVideoOffset");
         }
         if (tag_value != null) {
             int64 reverse_offset = int64.parse (tag_value);
@@ -348,9 +348,9 @@ public abstract class LivePhotoConv.LivePhoto : Object {
         var offset_string = reverse_offset.to_string ();
 
         string presentation_timestamp_us_to_write = "0";
-        // this.xmp_map contains tags loaded in the constructor
-        var original_motion_photo_ts = this.xmp_map.lookup("Xmp.Camera.MotionPhotoPresentationTimestampUs");
-        var original_gcamera_ts = this.xmp_map.lookup("Xmp.GCamera.MicroVideoPresentationTimestampUs");
+        // this.livemeta_map contains tags loaded in the constructor
+        var original_motion_photo_ts = this.livemeta_map.lookup("Xmp.Camera.MotionPhotoPresentationTimestampUs");
+        var original_gcamera_ts = this.livemeta_map.lookup("Xmp.GCamera.MicroVideoPresentationTimestampUs");
 
         if (original_motion_photo_ts != null && original_motion_photo_ts != "") {
             presentation_timestamp_us_to_write = original_motion_photo_ts;
@@ -359,15 +359,15 @@ public abstract class LivePhotoConv.LivePhoto : Object {
         }
 
         // Set GCamera (old standard) tags
-        this.xmp_map.insert ("Xmp.GCamera.MicroVideo", "1");
-        this.xmp_map.insert ("Xmp.GCamera.MicroVideoVersion", "1");
-        this.xmp_map.insert ("Xmp.GCamera.MicroVideoOffset", offset_string);
-        this.xmp_map.insert ("Xmp.GCamera.MicroVideoPresentationTimestampUs", presentation_timestamp_us_to_write);
+        this.livemeta_map.insert ("Xmp.GCamera.MicroVideo", "1");
+        this.livemeta_map.insert ("Xmp.GCamera.MicroVideoVersion", "1");
+        this.livemeta_map.insert ("Xmp.GCamera.MicroVideoOffset", offset_string);
+        this.livemeta_map.insert ("Xmp.GCamera.MicroVideoPresentationTimestampUs", presentation_timestamp_us_to_write);
 
-        // Add/Update new MotionPhoto standard tags in xmp_map
-        this.xmp_map.insert ("Xmp.GCamera.MotionPhoto", "1");
-        this.xmp_map.insert ("Xmp.GCamera.MotionPhotoVersion", "1");
-        this.xmp_map.insert ("Xmp.GCamera.MotionPhotoPresentationTimestampUs", presentation_timestamp_us_to_write);
+        // Add/Update new MotionPhoto standard tags in livemeta_map
+        this.livemeta_map.insert ("Xmp.GCamera.MotionPhoto", "1");
+        this.livemeta_map.insert ("Xmp.GCamera.MotionPhotoVersion", "1");
+        this.livemeta_map.insert ("Xmp.GCamera.MotionPhotoPresentationTimestampUs", presentation_timestamp_us_to_write);
         // Set Container and Item tags for MotionPhoto
         this.metadata.try_set_xmp_tag_struct ("Xmp.Container.Directory", GExiv2.StructureType.SEQ);
         this.metadata.try_set_tag_string ("Xmp.Container.Directory[1]/Container:Item", "type=Struct");
@@ -381,31 +381,40 @@ public abstract class LivePhotoConv.LivePhoto : Object {
         } else if (this.extension_name.down () == "avif") {
             image_mime_type = "image/avif";
         }
-        this.xmp_map.insert ("Xmp.Container.Directory[1]/Item:Mime", image_mime_type);
-        this.xmp_map.insert ("Xmp.Container.Directory[1]/Item:Semantic", "Primary");
+        this.livemeta_map.insert ("Xmp.Container.Directory[1]/Item:Mime", image_mime_type);
+        this.livemeta_map.insert ("Xmp.Container.Directory[1]/Item:Semantic", "Primary");
         // Item:Padding: For JPEG, optional (can be 0 or omitted). For HEIC/AVIF, must be 8.
         // This example assumes JPEG or doesn't set padding. A more robust solution would check image_mime_type.
         // if (image_mime_type == "image/heic" || image_mime_type == "image/avif") {
-        //    this.xmp_map.insert ("Xmp.Container.Directory[1]/Item:Padding", "8");
+        //    this.livemeta_map.insert ("Xmp.Container.Directory[1]/Item:Padding", "8");
         // }
 
         // Item 2: Video (assuming MP4)
-        this.xmp_map.insert ("Xmp.Container.Directory[2]/Item:Mime", "video/mp4");
-        this.xmp_map.insert ("Xmp.Container.Directory[2]/Item:Semantic", "MotionPhoto");
-        this.xmp_map.insert ("Xmp.Container.Directory[2]/Item:Length", offset_string); // offset_string is reverse_offset, i.e., video_size
+        this.livemeta_map.insert ("Xmp.Container.Directory[2]/Item:Mime", "video/mp4");
+        this.livemeta_map.insert ("Xmp.Container.Directory[2]/Item:Semantic", "MotionPhoto");
+        this.livemeta_map.insert ("Xmp.Container.Directory[2]/Item:Length", offset_string); // offset_string is reverse_offset, i.e., video_size
 
         // OPPO needs specific tags
         if (this.oppo_compatible) {
+            Reporter.info_puts ("OppoCompatibility", "Setting extra metadata for OPPO compatibility.");
             GExiv2.Metadata.try_register_xmp_namespace ("http://ns.oplus.com/photos/1.0/camera/", "OpCamera");
-            this.xmp_map.insert ("Xmp.OpCamera.MotionPhotoPrimaryPresentationTimestampUs", presentation_timestamp_us_to_write);
-            this.xmp_map.insert ("Xmp.OpCamera.MotionPhotoOwner", "oplus");
-            this.xmp_map.insert ("Xmp.OpCamera.OLivePhotoVersion", "2");
-            this.xmp_map.insert ("Xmp.OpCamera.VideoLength", offset_string);
+            this.livemeta_map.insert ("Xmp.OpCamera.MotionPhotoPrimaryPresentationTimestampUs", presentation_timestamp_us_to_write);
+            this.livemeta_map.insert ("Xmp.OpCamera.MotionPhotoOwner", "oplus");
+            this.livemeta_map.insert ("Xmp.OpCamera.OLivePhotoVersion", "2");
+            this.livemeta_map.insert ("Xmp.OpCamera.VideoLength", offset_string);
+            // oplus_11534368 is the constant used by OPPO Find X8s+, reported to work. Use it here for compatibility.
+            string? user_comment = null;
+            try {
+                user_comment = this.metadata.try_get_tag_string ("Exif.Photo.UserComment");
+            } catch {}
+            if (user_comment == null || (!user_comment.has_prefix ("oplus_"))) {
+                livemeta_map.insert ("Exif.Photo.UserComment", "oplus_11534368");
+            }
         }
 
         // Restore the XMP metadata for the live photo
         Error? metadata_error = null;
-        this.xmp_map.foreach ((key, value) => {
+        this.livemeta_map.foreach ((key, value) => {
             try {
                 this.metadata.try_set_tag_string (key, value);
                 return false;

--- a/src/main.vala
+++ b/src/main.vala
@@ -39,6 +39,7 @@ class LivePhotoConv.Main {
     static bool export_metadata = true;
     static bool frame_to_photo = false;
     static bool minimal_export = false;
+    static bool oppo_compatible = false;
     static int threads = 0;
 #if ENABLE_GST
     static bool use_ffmpeg = false;
@@ -54,6 +55,7 @@ class LivePhotoConv.Main {
         { "output", 'o', OptionFlags.NONE, OptionArg.FILENAME, ref live_photo_path, "The output live photo file path", "PATH" },
         { "export-metadata", '\0', OptionFlags.NONE, OptionArg.NONE, ref export_metadata, "Export metadata (default)", null },
         { "drop-metadata", '\0', OptionFlags.REVERSE, OptionArg.NONE, ref export_metadata, "Do not export metadata", null },
+        { "oppo-compatible", '\0', OptionFlags.NONE, OptionArg.NONE, ref oppo_compatible, "Required for OPPO compatibility", null },
 #if ENABLE_GST
         { "use-ffmpeg", '\0', OptionFlags.NONE, OptionArg.NONE, ref use_ffmpeg, "Use FFmpeg to extract instead of GStreamer", null },
         { "use-gst", '\0', OptionFlags.REVERSE, OptionArg.NONE, ref use_ffmpeg, "Use GStreamer to extract instead of FFmpeg (default)", null },
@@ -92,6 +94,7 @@ class LivePhotoConv.Main {
         { "live-photo", 'p', OptionFlags.NONE, OptionArg.FILENAME, ref live_photo_path, "The live photo file to repair (required)", "PATH" },
         { "force", 'f', OptionFlags.NONE, OptionArg.NONE, ref force_repair, "Force to update video offset in XMP metadata and repair", null },
         { "video-size", 's', OptionFlags.NONE, OptionArg.INT, ref repair_with_video_size, "Force repair with the specified video size", "SIZE" },
+        { "oppo-compatible", '\0', OptionFlags.NONE, OptionArg.NONE, ref oppo_compatible, "Required for OPPO compatibility", null },
         null
     };
 
@@ -116,6 +119,7 @@ class LivePhotoConv.Main {
         { "long-exposure", 'l', OptionFlags.NONE, OptionArg.FILENAME, ref long_exposure_path, "Convert the embedded video to a long exposure photo", "PATH" },
         { "minimal", '\0', OptionFlags.NONE, OptionArg.NONE, ref minimal_export, "Minimal export, ignore unspecified exports", null },
         { "threads", 'T', OptionFlags.NONE, OptionArg.INT, ref threads, "Number of threads to use for extracting, 0 for auto (not work in FFmpeg mode)", "NUM" },
+        { "oppo-compatible", '\0', OptionFlags.NONE, OptionArg.NONE, ref oppo_compatible, "Required for OPPO compatibility", null },
 #if ENABLE_GST
         { "use-ffmpeg", '\0', OptionFlags.NONE, OptionArg.NONE, ref use_ffmpeg, "Use FFmpeg to extract instead of GStreamer", null },
         { "use-gst", '\0', OptionFlags.REVERSE, OptionArg.NONE, ref use_ffmpeg, "Use GStreamer to extract instead of FFmpeg (default)", null },
@@ -250,19 +254,16 @@ class LivePhotoConv.Main {
         LivePhoto live_photo;
 #if ENABLE_GST
         if (use_ffmpeg) {
-            live_photo = new LivePhotoFFmpeg (live_photo_path, dest_dir) {
-                export_original_metadata = export_metadata,
-            };
+            live_photo = new LivePhotoFFmpeg (live_photo_path, dest_dir);
         } else {
-            live_photo = new LivePhotoGst (live_photo_path, dest_dir) {
-                export_original_metadata = export_metadata,
-            };
+            live_photo = new LivePhotoGst (live_photo_path, dest_dir);
         }
 #else
-        live_photo = new LivePhotoFFmpeg (live_photo_path, dest_dir) {
-            export_original_metadata = export_metadata,
-        };
+        live_photo = new LivePhotoFFmpeg (live_photo_path, dest_dir);
 #endif
+        live_photo.export_original_metadata = export_metadata;
+        live_photo.oppo_compatible = oppo_compatible;
+
         return live_photo;
     }
 
@@ -270,19 +271,16 @@ class LivePhotoConv.Main {
 #if ENABLE_GST
         LiveMaker live_maker;
         if (use_ffmpeg) {
-            live_maker = new LiveMakerFFmpeg (video_path, main_image_path, live_photo_path)  {
-                export_original_metadata = export_metadata,
-            };
+            live_maker = new LiveMakerFFmpeg (video_path, main_image_path, live_photo_path);
         } else {
-            live_maker = new LiveMakerGst (video_path, main_image_path, live_photo_path)  {
-                export_original_metadata = export_metadata,
-            };
+            live_maker = new LiveMakerGst (video_path, main_image_path, live_photo_path);
         }
 #else
-        LiveMaker live_maker = new LiveMakerFFmpeg (video_path, main_image_path, live_photo_path)  {
-            export_original_metadata = export_metadata,
-        };
+        LiveMaker live_maker = new LiveMakerFFmpeg (video_path, main_image_path, live_photo_path);
 #endif
+        live_maker.export_original_metadata = export_metadata;
+        live_maker.oppo_compatible = oppo_compatible;
+
         live_maker.export ();
     }
 


### PR DESCRIPTION
Add support for OPPO-specific metadata tags required for proper Live Photo playback on OPPO devices. Introduce a new command-line option `--oppo-compatible` to enable this mode, which adds the following tags:
- Xmp.OpCamera.MotionPhotoPrimaryPresentationTimestampUs
- Xmp.OpCamera.MotionPhotoOwner
- Xmp.OpCamera.OLivePhotoVersion
- Xmp.OpCamera.VideoLength
- Exif.Photo.UserComment

The option is propagated to both LivePhoto and LiveMaker. Namespace registration for "OpCamera" is handled dynamically when needed.