### PR TITLE
feat: add full i18n support for GUI

### DIFF
--- a/assets/com.github.wszqkzqk.live-photo-conv.desktop
+++ b/assets/com.github.wszqkzqk.live-photo-conv.desktop
@@ -1,6 +1,22 @@
 [Desktop Entry]
 Name=Live Photo Converter
+Name[de]=Live Photo Konverter
+Name[es]=Conversor de Live Photo
+Name[fr]=Convertisseur Live Photo
+Name[ja]=Live Photo コンバーター
+Name[ko]=Live Photo 변환기
+Name[pt_BR]=Conversor de Live Photo
+Name[ru]=Конвертер Live Photo
+Name[zh_CN]=动态照片转换器
 Comment=Convert, extract and repair Android Live Photos
+Comment[de]=Android Live Photos konvertieren, extrahieren und reparieren
+Comment[es]=Convierte, extrae y repara Live Photos de Android
+Comment[fr]=Convertissez, extrayez et réparez des Live Photos Android
+Comment[ja]=Android Live Photo の変換、抽出、修復
+Comment[ko]=Android Live Photo 변환, 추출 및 복구
+Comment[pt_BR]=Converta, extraia e repare Live Photos do Android
+Comment[ru]=Конвертируйте, извлекайте и восстанавливайте Android Live Photos
+Comment[zh_CN]=转换、提取和修复 Android 动态照片
 Exec=live-photo-conv-gtk
 Icon=com.github.wszqkzqk.live-photo-conv
 Type=Application

--- a/assets/com.github.wszqkzqk.live-photo-conv.desktop
+++ b/assets/com.github.wszqkzqk.live-photo-conv.desktop
@@ -1,13 +1,5 @@
 [Desktop Entry]
 Name=Live Photo Converter
-Name[de]=Live Photo Konverter
-Name[es]=Conversor de Live Photo
-Name[fr]=Convertisseur Live Photo
-Name[ja]=Live Photo コンバーター
-Name[ko]=Live Photo 변환기
-Name[pt_BR]=Conversor de Live Photo
-Name[ru]=Конвертер Live Photo
-Name[zh_CN]=动态照片转换器
 Comment=Convert, extract and repair Android Live Photos
 Comment[de]=Android Live Photos konvertieren, extrahieren und reparieren
 Comment[es]=Convierte, extrae y repara Live Photos de Android

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('live-photo-conv', ['c', 'vala'],
           version: '0.40.2',
-    meson_version: '>= 1.1',
+    meson_version: '>= 1.4',
 )
 
 # Library versioning
@@ -51,7 +51,11 @@ endif
 # Other tool dependencies
 pkg = import('pkgconfig')
 gnome = import('gnome')
+i18n = import('i18n')
 python = import('python').find_installation()
+
+# i18n - must be defined before vala sources that use _()
+add_project_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), language: 'c')
 
 # Optional tools
 g_ir_compiler = find_program('g-ir-compiler', required: get_option('gir'))
@@ -61,6 +65,8 @@ valadoc = find_program('valadoc', required: get_option('docs'))
 #incdir = include_directories('include')
 
 subdir('src')
+
+subdir('po')
 
 if with_gui and is_freedesktop
   gnome.post_install (

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,0 +1,8 @@
+de
+es
+fr
+ja
+ko
+pt_BR
+ru
+zh_CN

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,0 +1,4 @@
+# List of source files containing translatable strings.
+# Paths are relative to the project source root.
+# Please keep this file sorted alphabetically.
+src/gui.vala

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,266 @@
+# German translations for live-photo-conv package.
+# Copyright (C) 2026 THE live-photo-conv'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the live-photo-conv package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: live-photo-conv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"PO-Revision-Date: 2026-05-04 14:06+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/gui.vala:64
+#, c-format
+msgid "%u file selected"
+msgid_plural "%u files selected"
+msgstr[0] "%u Datei ausgewählt"
+msgstr[1] "%u Dateien ausgewählt"
+
+#: src/gui.vala:294 src/gui.vala:404
+msgid "Live Photo Converter"
+msgstr "Live Photo Konverter"
+
+#: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
+msgid "Make Live Photo"
+msgstr "Live Photo erstellen"
+
+#: src/gui.vala:312 src/gui.vala:319 src/gui.vala:636 src/gui.vala:639
+msgid "Extract"
+msgstr "Extrahieren"
+
+#: src/gui.vala:315 src/gui.vala:320 src/gui.vala:737 src/gui.vala:740
+msgid "Repair"
+msgstr "Reparieren"
+
+#: src/gui.vala:318
+msgid "Make"
+msgstr "Erstellen"
+
+#: src/gui.vala:328
+msgid "Follow System"
+msgstr "System folgen"
+
+#: src/gui.vala:329
+msgid "Light"
+msgstr "Hell"
+
+#: src/gui.vala:330
+msgid "Dark"
+msgstr "Dunkel"
+
+#: src/gui.vala:334
+msgid "Appearance"
+msgstr "Erscheinungsbild"
+
+#: src/gui.vala:335
+msgid "About"
+msgstr "Über"
+
+#: src/gui.vala:473
+msgid "Source Files"
+msgstr "Quelldateien"
+
+#: src/gui.vala:474
+msgid "Provide a video file (required) and a static image."
+msgstr "Eine Videodatei (erforderlich) und ein statisches Bild bereitstellen."
+
+#: src/gui.vala:486
+msgid "Video"
+msgstr "Video"
+
+#: src/gui.vala:490
+msgid ""
+"Drop video here\n"
+"or click to browse"
+msgstr ""
+"Video hier ablegen\n"
+"oder zum Durchsuchen klicken"
+
+#: src/gui.vala:503
+msgid "Main Image"
+msgstr "Hauptbild"
+
+#: src/gui.vala:507
+msgid ""
+"Drop image here\n"
+"or click to browse"
+msgstr ""
+"Bild hier ablegen\n"
+"oder zum Durchsuchen klicken"
+
+#: src/gui.vala:518
+msgid "Options"
+msgstr "Optionen"
+
+#: src/gui.vala:520
+msgid "Export metadata"
+msgstr "Metadaten exportieren"
+
+#: src/gui.vala:531
+msgid "Save Live Photo As"
+msgstr "Live Photo speichern als"
+
+#: src/gui.vala:545
+msgid "Processing…"
+msgstr "Verarbeitung…"
+
+#: src/gui.vala:560
+msgid "Live photo created"
+msgstr "Live Photo erstellt"
+
+#: src/gui.vala:563 src/gui.vala:640 src/gui.vala:741
+#, c-format
+msgid "Error: %s"
+msgstr "Fehler: %s"
+
+#: src/gui.vala:577 src/gui.vala:654
+msgid "Live Photo"
+msgstr "Live Photo"
+
+#: src/gui.vala:578
+msgid "Select the live photo file to extract from."
+msgstr "Wählen Sie die zu extrahierende Live-Photo-Datei aus."
+
+#: src/gui.vala:580 src/gui.vala:657
+msgid ""
+"Drop live photo file here\n"
+"or click to browse"
+msgstr ""
+"Live-Photo-Datei hier ablegen\n"
+"oder zum Durchsuchen klicken"
+
+#: src/gui.vala:593
+msgid "Export Items"
+msgstr "Exportelemente"
+
+#: src/gui.vala:594
+msgid "Choose what to extract from the live photo."
+msgstr "Wählen Sie, was aus dem Live Photo extrahiert werden soll."
+
+#: src/gui.vala:596
+msgid "Export Main Image"
+msgstr "Hauptbild exportieren"
+
+#: src/gui.vala:597
+msgid "Export Video"
+msgstr "Video exportieren"
+
+#: src/gui.vala:598
+msgid "Export Frames as Photos"
+msgstr "Einzelbilder als Fotos exportieren"
+
+#: src/gui.vala:599
+msgid "Export Long Exposure Photo"
+msgstr "Langzeitbelichtungsfoto exportieren"
+
+#: src/gui.vala:600
+msgid "Image Format"
+msgstr "Bildformat"
+
+#: src/gui.vala:600
+msgid "auto"
+msgstr "automatisch"
+
+#: src/gui.vala:609 src/gui.vala:726
+msgid "Please select a live photo file first"
+msgstr "Bitte wählen Sie zuerst eine Live-Photo-Datei aus"
+
+#: src/gui.vala:614
+msgid "Select Output Directory"
+msgstr "Ausgabeverzeichnis auswählen"
+
+#: src/gui.vala:629
+msgid "Extracting…"
+msgstr "Extraktion…"
+
+#: src/gui.vala:637
+#, c-format
+msgid "%u file extracted"
+msgid_plural "%u files extracted"
+msgstr[0] "%u Datei extrahiert"
+msgstr[1] "%u Dateien extrahiert"
+
+#: src/gui.vala:655
+msgid "Select the live photo file to repair its XMP metadata."
+msgstr ""
+"Wählen Sie die Live-Photo-Datei, deren XMP-Metadaten repariert werden sollen."
+
+#: src/gui.vala:670
+msgid "Repair Options"
+msgstr "Reparaturoptionen"
+
+#: src/gui.vala:672
+msgid "Force Repair"
+msgstr "Reparatur erzwingen"
+
+#: src/gui.vala:674
+msgid ""
+"If enabled, the video offset will be re-discovered by scanning\n"
+"the entire file for the MP4 header, overriding any existing\n"
+"offset value in the XMP metadata."
+msgstr ""
+"Wenn aktiviert, wird der Video-Offset durch Scannen\n"
+"der gesamten Datei nach dem MP4-Header neu ermittelt,\n"
+"wobei vorhandene Offset-Werte in den XMP-Metadaten\n"
+"überschrieben werden."
+
+#: src/gui.vala:680
+msgid "Advanced"
+msgstr "Erweitert"
+
+#: src/gui.vala:682
+msgid "Manual Video Size"
+msgstr "Manuelle Videogröße"
+
+#: src/gui.vala:683
+msgid "Specify the size of the embedded video in bytes"
+msgstr "Größe des eingebetteten Videos in Bytes angeben"
+
+#: src/gui.vala:684
+msgid ""
+"If the video size cannot be detected automatically,\n"
+"you can manually specify its size in bytes.\n"
+"Leave at 0 to use automatic detection."
+msgstr ""
+"Wenn die Videogröße nicht automatisch erkannt werden kann,\n"
+"können Sie die Größe manuell in Bytes angeben.\n"
+"Bei 0 wird die automatische Erkennung verwendet."
+
+#: src/gui.vala:699
+msgid ""
+"Enter the exact size of the video portion in bytes.\n"
+"Only needed if automatic detection fails."
+msgstr ""
+"Geben Sie die genaue Größe des Videoteils in Bytes ein.\n"
+"Nur erforderlich, wenn die automatische Erkennung fehlschlägt."
+
+#: src/gui.vala:709
+msgid "Video size in bytes"
+msgstr "Videogröße in Bytes"
+
+#: src/gui.vala:733
+msgid "Repairing…"
+msgstr "Reparatur…"
+
+#: src/gui.vala:738
+#, c-format
+msgid "%u file repaired"
+msgid_plural "%u files repaired"
+msgstr[0] "%u Datei repariert"
+msgstr[1] "%u Dateien repariert"
+
+#: src/gui.vala:763 src/gui.vala:790
+msgid "Extracting"
+msgstr "Extraktion"
+
+#: src/gui.vala:809 src/gui.vala:827
+msgid "Repairing"
+msgstr "Reparatur"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-photo-conv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"POT-Creation-Date: 2026-05-04 17:44+0800\n"
 "PO-Revision-Date: 2026-05-04 14:06+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -23,10 +23,6 @@ msgid "%u file selected"
 msgid_plural "%u files selected"
 msgstr[0] "%u Datei ausgewählt"
 msgstr[1] "%u Dateien ausgewählt"
-
-#: src/gui.vala:294 src/gui.vala:404
-msgid "Live Photo Converter"
-msgstr "Live Photo Konverter"
 
 #: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
 msgid "Make Live Photo"
@@ -264,3 +260,6 @@ msgstr "Extraktion"
 #: src/gui.vala:809 src/gui.vala:827
 msgid "Repairing"
 msgstr "Reparatur"
+
+#~ msgid "Live Photo Converter"
+#~ msgstr "Live Photo Konverter"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-photo-conv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"POT-Creation-Date: 2026-05-04 17:44+0800\n"
 "PO-Revision-Date: 2026-05-04 14:06+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -23,10 +23,6 @@ msgid "%u file selected"
 msgid_plural "%u files selected"
 msgstr[0] "%u archivo seleccionado"
 msgstr[1] "%u archivos seleccionados"
-
-#: src/gui.vala:294 src/gui.vala:404
-msgid "Live Photo Converter"
-msgstr "Conversor de Live Photo"
 
 #: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
 msgid "Make Live Photo"
@@ -263,3 +259,6 @@ msgstr "Extrayendo"
 #: src/gui.vala:809 src/gui.vala:827
 msgid "Repairing"
 msgstr "Reparando"
+
+#~ msgid "Live Photo Converter"
+#~ msgstr "Conversor de Live Photo"

--- a/po/es.po
+++ b/po/es.po
@@ -1,0 +1,265 @@
+# Spanish translations for live-photo-conv package.
+# Copyright (C) 2026 THE live-photo-conv'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the live-photo-conv package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: live-photo-conv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"PO-Revision-Date: 2026-05-04 14:06+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/gui.vala:64
+#, c-format
+msgid "%u file selected"
+msgid_plural "%u files selected"
+msgstr[0] "%u archivo seleccionado"
+msgstr[1] "%u archivos seleccionados"
+
+#: src/gui.vala:294 src/gui.vala:404
+msgid "Live Photo Converter"
+msgstr "Conversor de Live Photo"
+
+#: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
+msgid "Make Live Photo"
+msgstr "Crear Live Photo"
+
+#: src/gui.vala:312 src/gui.vala:319 src/gui.vala:636 src/gui.vala:639
+msgid "Extract"
+msgstr "Extraer"
+
+#: src/gui.vala:315 src/gui.vala:320 src/gui.vala:737 src/gui.vala:740
+msgid "Repair"
+msgstr "Reparar"
+
+#: src/gui.vala:318
+msgid "Make"
+msgstr "Crear"
+
+#: src/gui.vala:328
+msgid "Follow System"
+msgstr "Seguir sistema"
+
+#: src/gui.vala:329
+msgid "Light"
+msgstr "Claro"
+
+#: src/gui.vala:330
+msgid "Dark"
+msgstr "Oscuro"
+
+#: src/gui.vala:334
+msgid "Appearance"
+msgstr "Apariencia"
+
+#: src/gui.vala:335
+msgid "About"
+msgstr "Acerca de"
+
+#: src/gui.vala:473
+msgid "Source Files"
+msgstr "Archivos de origen"
+
+#: src/gui.vala:474
+msgid "Provide a video file (required) and a static image."
+msgstr "Proporcione un archivo de video (obligatorio) y una imagen estática."
+
+#: src/gui.vala:486
+msgid "Video"
+msgstr "Video"
+
+#: src/gui.vala:490
+msgid ""
+"Drop video here\n"
+"or click to browse"
+msgstr ""
+"Suelte el video aquí\n"
+"o haga clic para explorar"
+
+#: src/gui.vala:503
+msgid "Main Image"
+msgstr "Imagen principal"
+
+#: src/gui.vala:507
+msgid ""
+"Drop image here\n"
+"or click to browse"
+msgstr ""
+"Suelte la imagen aquí\n"
+"o haga clic para explorar"
+
+#: src/gui.vala:518
+msgid "Options"
+msgstr "Opciones"
+
+#: src/gui.vala:520
+msgid "Export metadata"
+msgstr "Exportar metadatos"
+
+#: src/gui.vala:531
+msgid "Save Live Photo As"
+msgstr "Guardar Live Photo como"
+
+#: src/gui.vala:545
+msgid "Processing…"
+msgstr "Procesando…"
+
+#: src/gui.vala:560
+msgid "Live photo created"
+msgstr "Live Photo creada"
+
+#: src/gui.vala:563 src/gui.vala:640 src/gui.vala:741
+#, c-format
+msgid "Error: %s"
+msgstr "Error: %s"
+
+#: src/gui.vala:577 src/gui.vala:654
+msgid "Live Photo"
+msgstr "Live Photo"
+
+#: src/gui.vala:578
+msgid "Select the live photo file to extract from."
+msgstr "Seleccione el archivo Live Photo del que extraer."
+
+#: src/gui.vala:580 src/gui.vala:657
+msgid ""
+"Drop live photo file here\n"
+"or click to browse"
+msgstr ""
+"Suelte el archivo Live Photo aquí\n"
+"o haga clic para explorar"
+
+#: src/gui.vala:593
+msgid "Export Items"
+msgstr "Elementos a exportar"
+
+#: src/gui.vala:594
+msgid "Choose what to extract from the live photo."
+msgstr "Elija qué extraer de la Live Photo."
+
+#: src/gui.vala:596
+msgid "Export Main Image"
+msgstr "Exportar imagen principal"
+
+#: src/gui.vala:597
+msgid "Export Video"
+msgstr "Exportar video"
+
+#: src/gui.vala:598
+msgid "Export Frames as Photos"
+msgstr "Exportar fotogramas como fotos"
+
+#: src/gui.vala:599
+msgid "Export Long Exposure Photo"
+msgstr "Exportar foto de larga exposición"
+
+#: src/gui.vala:600
+msgid "Image Format"
+msgstr "Formato de imagen"
+
+#: src/gui.vala:600
+msgid "auto"
+msgstr "automático"
+
+#: src/gui.vala:609 src/gui.vala:726
+msgid "Please select a live photo file first"
+msgstr "Seleccione primero un archivo Live Photo"
+
+#: src/gui.vala:614
+msgid "Select Output Directory"
+msgstr "Seleccionar directorio de salida"
+
+#: src/gui.vala:629
+msgid "Extracting…"
+msgstr "Extrayendo…"
+
+#: src/gui.vala:637
+#, c-format
+msgid "%u file extracted"
+msgid_plural "%u files extracted"
+msgstr[0] "%u archivo extraído"
+msgstr[1] "%u archivos extraídos"
+
+#: src/gui.vala:655
+msgid "Select the live photo file to repair its XMP metadata."
+msgstr "Seleccione el archivo Live Photo para reparar sus metadatos XMP."
+
+#: src/gui.vala:670
+msgid "Repair Options"
+msgstr "Opciones de reparación"
+
+#: src/gui.vala:672
+msgid "Force Repair"
+msgstr "Forzar reparación"
+
+#: src/gui.vala:674
+msgid ""
+"If enabled, the video offset will be re-discovered by scanning\n"
+"the entire file for the MP4 header, overriding any existing\n"
+"offset value in the XMP metadata."
+msgstr ""
+"Si se habilita, el desplazamiento de video se redescubrirá\n"
+"escaneando todo el archivo en busca del encabezado MP4,\n"
+"anulando cualquier valor de desplazamiento existente\n"
+"en los metadatos XMP."
+
+#: src/gui.vala:680
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: src/gui.vala:682
+msgid "Manual Video Size"
+msgstr "Tamaño de video manual"
+
+#: src/gui.vala:683
+msgid "Specify the size of the embedded video in bytes"
+msgstr "Especificar el tamaño del video incrustado en bytes"
+
+#: src/gui.vala:684
+msgid ""
+"If the video size cannot be detected automatically,\n"
+"you can manually specify its size in bytes.\n"
+"Leave at 0 to use automatic detection."
+msgstr ""
+"Si el tamaño del video no se puede detectar automáticamente,\n"
+"puede especificar manualmente su tamaño en bytes.\n"
+"Déjelo en 0 para usar la detección automática."
+
+#: src/gui.vala:699
+msgid ""
+"Enter the exact size of the video portion in bytes.\n"
+"Only needed if automatic detection fails."
+msgstr ""
+"Ingrese el tamaño exacto de la parte de video en bytes.\n"
+"Solo necesario si falla la detección automática."
+
+#: src/gui.vala:709
+msgid "Video size in bytes"
+msgstr "Tamaño de video en bytes"
+
+#: src/gui.vala:733
+msgid "Repairing…"
+msgstr "Reparando…"
+
+#: src/gui.vala:738
+#, c-format
+msgid "%u file repaired"
+msgid_plural "%u files repaired"
+msgstr[0] "%u archivo reparado"
+msgstr[1] "%u archivos reparados"
+
+#: src/gui.vala:763 src/gui.vala:790
+msgid "Extracting"
+msgstr "Extrayendo"
+
+#: src/gui.vala:809 src/gui.vala:827
+msgid "Repairing"
+msgstr "Reparando"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-photo-conv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"POT-Creation-Date: 2026-05-04 17:44+0800\n"
 "PO-Revision-Date: 2026-05-04 14:06+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -23,10 +23,6 @@ msgid "%u file selected"
 msgid_plural "%u files selected"
 msgstr[0] "%u fichier sélectionné"
 msgstr[1] "%u fichiers sélectionnés"
-
-#: src/gui.vala:294 src/gui.vala:404
-msgid "Live Photo Converter"
-msgstr "Convertisseur Live Photo"
 
 #: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
 msgid "Make Live Photo"
@@ -263,3 +259,6 @@ msgstr "Extraction"
 #: src/gui.vala:809 src/gui.vala:827
 msgid "Repairing"
 msgstr "Réparation"
+
+#~ msgid "Live Photo Converter"
+#~ msgstr "Convertisseur Live Photo"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,265 @@
+# French translations for live-photo-conv package.
+# Copyright (C) 2026 THE live-photo-conv'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the live-photo-conv package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: live-photo-conv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"PO-Revision-Date: 2026-05-04 14:06+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: src/gui.vala:64
+#, c-format
+msgid "%u file selected"
+msgid_plural "%u files selected"
+msgstr[0] "%u fichier sélectionné"
+msgstr[1] "%u fichiers sélectionnés"
+
+#: src/gui.vala:294 src/gui.vala:404
+msgid "Live Photo Converter"
+msgstr "Convertisseur Live Photo"
+
+#: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
+msgid "Make Live Photo"
+msgstr "Créer une Live Photo"
+
+#: src/gui.vala:312 src/gui.vala:319 src/gui.vala:636 src/gui.vala:639
+msgid "Extract"
+msgstr "Extraire"
+
+#: src/gui.vala:315 src/gui.vala:320 src/gui.vala:737 src/gui.vala:740
+msgid "Repair"
+msgstr "Réparer"
+
+#: src/gui.vala:318
+msgid "Make"
+msgstr "Créer"
+
+#: src/gui.vala:328
+msgid "Follow System"
+msgstr "Suivre le système"
+
+#: src/gui.vala:329
+msgid "Light"
+msgstr "Clair"
+
+#: src/gui.vala:330
+msgid "Dark"
+msgstr "Sombre"
+
+#: src/gui.vala:334
+msgid "Appearance"
+msgstr "Apparence"
+
+#: src/gui.vala:335
+msgid "About"
+msgstr "À propos"
+
+#: src/gui.vala:473
+msgid "Source Files"
+msgstr "Fichiers source"
+
+#: src/gui.vala:474
+msgid "Provide a video file (required) and a static image."
+msgstr "Fournir un fichier vidéo (obligatoire) et une image statique."
+
+#: src/gui.vala:486
+msgid "Video"
+msgstr "Vidéo"
+
+#: src/gui.vala:490
+msgid ""
+"Drop video here\n"
+"or click to browse"
+msgstr ""
+"Déposez la vidéo ici\n"
+"ou cliquez pour parcourir"
+
+#: src/gui.vala:503
+msgid "Main Image"
+msgstr "Image principale"
+
+#: src/gui.vala:507
+msgid ""
+"Drop image here\n"
+"or click to browse"
+msgstr ""
+"Déposez l'image ici\n"
+"ou cliquez pour parcourir"
+
+#: src/gui.vala:518
+msgid "Options"
+msgstr "Options"
+
+#: src/gui.vala:520
+msgid "Export metadata"
+msgstr "Exporter les métadonnées"
+
+#: src/gui.vala:531
+msgid "Save Live Photo As"
+msgstr "Enregistrer la Live Photo sous"
+
+#: src/gui.vala:545
+msgid "Processing…"
+msgstr "Traitement…"
+
+#: src/gui.vala:560
+msgid "Live photo created"
+msgstr "Live Photo créée"
+
+#: src/gui.vala:563 src/gui.vala:640 src/gui.vala:741
+#, c-format
+msgid "Error: %s"
+msgstr "Erreur : %s"
+
+#: src/gui.vala:577 src/gui.vala:654
+msgid "Live Photo"
+msgstr "Live Photo"
+
+#: src/gui.vala:578
+msgid "Select the live photo file to extract from."
+msgstr "Sélectionnez le fichier Live Photo à extraire."
+
+#: src/gui.vala:580 src/gui.vala:657
+msgid ""
+"Drop live photo file here\n"
+"or click to browse"
+msgstr ""
+"Déposez le fichier Live Photo ici\n"
+"ou cliquez pour parcourir"
+
+#: src/gui.vala:593
+msgid "Export Items"
+msgstr "Éléments à exporter"
+
+#: src/gui.vala:594
+msgid "Choose what to extract from the live photo."
+msgstr "Choisissez ce qu'il faut extraire de la Live Photo."
+
+#: src/gui.vala:596
+msgid "Export Main Image"
+msgstr "Exporter l'image principale"
+
+#: src/gui.vala:597
+msgid "Export Video"
+msgstr "Exporter la vidéo"
+
+#: src/gui.vala:598
+msgid "Export Frames as Photos"
+msgstr "Exporter les images en photos"
+
+#: src/gui.vala:599
+msgid "Export Long Exposure Photo"
+msgstr "Exporter la photo longue exposition"
+
+#: src/gui.vala:600
+msgid "Image Format"
+msgstr "Format d'image"
+
+#: src/gui.vala:600
+msgid "auto"
+msgstr "auto"
+
+#: src/gui.vala:609 src/gui.vala:726
+msgid "Please select a live photo file first"
+msgstr "Veuillez d'abord sélectionner un fichier Live Photo"
+
+#: src/gui.vala:614
+msgid "Select Output Directory"
+msgstr "Sélectionner le dossier de sortie"
+
+#: src/gui.vala:629
+msgid "Extracting…"
+msgstr "Extraction…"
+
+#: src/gui.vala:637
+#, c-format
+msgid "%u file extracted"
+msgid_plural "%u files extracted"
+msgstr[0] "%u fichier extrait"
+msgstr[1] "%u fichiers extraits"
+
+#: src/gui.vala:655
+msgid "Select the live photo file to repair its XMP metadata."
+msgstr "Sélectionnez le fichier Live Photo pour réparer ses métadonnées XMP."
+
+#: src/gui.vala:670
+msgid "Repair Options"
+msgstr "Options de réparation"
+
+#: src/gui.vala:672
+msgid "Force Repair"
+msgstr "Forcer la réparation"
+
+#: src/gui.vala:674
+msgid ""
+"If enabled, the video offset will be re-discovered by scanning\n"
+"the entire file for the MP4 header, overriding any existing\n"
+"offset value in the XMP metadata."
+msgstr ""
+"Si activé, le décalage vidéo sera redécouvert en analysant\n"
+"l'intégralité du fichier à la recherche de l'en-tête MP4,\n"
+"remplaçant toute valeur de décalage existante\n"
+"dans les métadonnées XMP."
+
+#: src/gui.vala:680
+msgid "Advanced"
+msgstr "Avancé"
+
+#: src/gui.vala:682
+msgid "Manual Video Size"
+msgstr "Taille vidéo manuelle"
+
+#: src/gui.vala:683
+msgid "Specify the size of the embedded video in bytes"
+msgstr "Spécifier la taille de la vidéo intégrée en octets"
+
+#: src/gui.vala:684
+msgid ""
+"If the video size cannot be detected automatically,\n"
+"you can manually specify its size in bytes.\n"
+"Leave at 0 to use automatic detection."
+msgstr ""
+"Si la taille de la vidéo ne peut pas être détectée automatiquement,\n"
+"vous pouvez spécifier manuellement sa taille en octets.\n"
+"Laissez à 0 pour utiliser la détection automatique."
+
+#: src/gui.vala:699
+msgid ""
+"Enter the exact size of the video portion in bytes.\n"
+"Only needed if automatic detection fails."
+msgstr ""
+"Entrez la taille exacte de la partie vidéo en octets.\n"
+"Nécessaire uniquement si la détection automatique échoue."
+
+#: src/gui.vala:709
+msgid "Video size in bytes"
+msgstr "Taille vidéo en octets"
+
+#: src/gui.vala:733
+msgid "Repairing…"
+msgstr "Réparation…"
+
+#: src/gui.vala:738
+#, c-format
+msgid "%u file repaired"
+msgid_plural "%u files repaired"
+msgstr[0] "%u fichier réparé"
+msgstr[1] "%u fichiers réparés"
+
+#: src/gui.vala:763 src/gui.vala:790
+msgid "Extracting"
+msgstr "Extraction"
+
+#: src/gui.vala:809 src/gui.vala:827
+msgid "Repairing"
+msgstr "Réparation"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-photo-conv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"POT-Creation-Date: 2026-05-04 17:44+0800\n"
 "PO-Revision-Date: 2026-05-04 14:06+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -22,10 +22,6 @@ msgstr ""
 msgid "%u file selected"
 msgid_plural "%u files selected"
 msgstr[0] "%u 個のファイルが選択されました"
-
-#: src/gui.vala:294 src/gui.vala:404
-msgid "Live Photo Converter"
-msgstr "Live Photo コンバーター"
 
 #: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
 msgid "Make Live Photo"
@@ -259,3 +255,6 @@ msgstr "抽出中"
 #: src/gui.vala:809 src/gui.vala:827
 msgid "Repairing"
 msgstr "修復中"
+
+#~ msgid "Live Photo Converter"
+#~ msgstr "Live Photo コンバーター"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,0 +1,261 @@
+# Japanese translations for live-photo-conv package.
+# Copyright (C) 2026 THE live-photo-conv'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the live-photo-conv package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: live-photo-conv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"PO-Revision-Date: 2026-05-04 14:06+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/gui.vala:64
+#, c-format
+msgid "%u file selected"
+msgid_plural "%u files selected"
+msgstr[0] "%u 個のファイルが選択されました"
+
+#: src/gui.vala:294 src/gui.vala:404
+msgid "Live Photo Converter"
+msgstr "Live Photo コンバーター"
+
+#: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
+msgid "Make Live Photo"
+msgstr "Live Photo を作成"
+
+#: src/gui.vala:312 src/gui.vala:319 src/gui.vala:636 src/gui.vala:639
+msgid "Extract"
+msgstr "抽出"
+
+#: src/gui.vala:315 src/gui.vala:320 src/gui.vala:737 src/gui.vala:740
+msgid "Repair"
+msgstr "修復"
+
+#: src/gui.vala:318
+msgid "Make"
+msgstr "作成"
+
+#: src/gui.vala:328
+msgid "Follow System"
+msgstr "システムに従う"
+
+#: src/gui.vala:329
+msgid "Light"
+msgstr "ライト"
+
+#: src/gui.vala:330
+msgid "Dark"
+msgstr "ダーク"
+
+#: src/gui.vala:334
+msgid "Appearance"
+msgstr "外観"
+
+#: src/gui.vala:335
+msgid "About"
+msgstr "このアプリについて"
+
+#: src/gui.vala:473
+msgid "Source Files"
+msgstr "ソースファイル"
+
+#: src/gui.vala:474
+msgid "Provide a video file (required) and a static image."
+msgstr "動画ファイル（必須）と静止画像を指定してください。"
+
+#: src/gui.vala:486
+msgid "Video"
+msgstr "動画"
+
+#: src/gui.vala:490
+msgid ""
+"Drop video here\n"
+"or click to browse"
+msgstr ""
+"動画をここにドロップ\n"
+"またはクリックして参照"
+
+#: src/gui.vala:503
+msgid "Main Image"
+msgstr "メイン画像"
+
+#: src/gui.vala:507
+msgid ""
+"Drop image here\n"
+"or click to browse"
+msgstr ""
+"画像をここにドロップ\n"
+"またはクリックして参照"
+
+#: src/gui.vala:518
+msgid "Options"
+msgstr "オプション"
+
+#: src/gui.vala:520
+msgid "Export metadata"
+msgstr "メタデータをエクスポート"
+
+#: src/gui.vala:531
+msgid "Save Live Photo As"
+msgstr "Live Photo を保存"
+
+#: src/gui.vala:545
+msgid "Processing…"
+msgstr "処理中…"
+
+#: src/gui.vala:560
+msgid "Live photo created"
+msgstr "Live Photo が作成されました"
+
+#: src/gui.vala:563 src/gui.vala:640 src/gui.vala:741
+#, c-format
+msgid "Error: %s"
+msgstr "エラー：%s"
+
+#: src/gui.vala:577 src/gui.vala:654
+msgid "Live Photo"
+msgstr "Live Photo"
+
+#: src/gui.vala:578
+msgid "Select the live photo file to extract from."
+msgstr "抽出元の Live Photo ファイルを選択してください。"
+
+#: src/gui.vala:580 src/gui.vala:657
+msgid ""
+"Drop live photo file here\n"
+"or click to browse"
+msgstr ""
+"Live Photo ファイルをここにドロップ\n"
+"またはクリックして参照"
+
+#: src/gui.vala:593
+msgid "Export Items"
+msgstr "エクスポート項目"
+
+#: src/gui.vala:594
+msgid "Choose what to extract from the live photo."
+msgstr "Live Photo から抽出するものを選択してください。"
+
+#: src/gui.vala:596
+msgid "Export Main Image"
+msgstr "メイン画像をエクスポート"
+
+#: src/gui.vala:597
+msgid "Export Video"
+msgstr "動画をエクスポート"
+
+#: src/gui.vala:598
+msgid "Export Frames as Photos"
+msgstr "フレームを写真としてエクスポート"
+
+#: src/gui.vala:599
+msgid "Export Long Exposure Photo"
+msgstr "長時間露光写真をエクスポート"
+
+#: src/gui.vala:600
+msgid "Image Format"
+msgstr "画像形式"
+
+#: src/gui.vala:600
+msgid "auto"
+msgstr "自動"
+
+#: src/gui.vala:609 src/gui.vala:726
+msgid "Please select a live photo file first"
+msgstr "先に Live Photo ファイルを選択してください"
+
+#: src/gui.vala:614
+msgid "Select Output Directory"
+msgstr "出力ディレクトリを選択"
+
+#: src/gui.vala:629
+msgid "Extracting…"
+msgstr "抽出中…"
+
+#: src/gui.vala:637
+#, c-format
+msgid "%u file extracted"
+msgid_plural "%u files extracted"
+msgstr[0] "%u 個のファイルを抽出しました"
+
+#: src/gui.vala:655
+msgid "Select the live photo file to repair its XMP metadata."
+msgstr "XMP メタデータを修復する Live Photo ファイルを選択してください。"
+
+#: src/gui.vala:670
+msgid "Repair Options"
+msgstr "修復オプション"
+
+#: src/gui.vala:672
+msgid "Force Repair"
+msgstr "強制修復"
+
+#: src/gui.vala:674
+msgid ""
+"If enabled, the video offset will be re-discovered by scanning\n"
+"the entire file for the MP4 header, overriding any existing\n"
+"offset value in the XMP metadata."
+msgstr ""
+"有効にすると、ファイル全体をスキャンして\n"
+"MP4 ヘッダーを再検出し、XMP メタデータ内の\n"
+"既存のオフセット値を上書きします。"
+
+#: src/gui.vala:680
+msgid "Advanced"
+msgstr "詳細"
+
+#: src/gui.vala:682
+msgid "Manual Video Size"
+msgstr "動画サイズを手動指定"
+
+#: src/gui.vala:683
+msgid "Specify the size of the embedded video in bytes"
+msgstr "埋め込み動画のサイズをバイト単位で指定"
+
+#: src/gui.vala:684
+msgid ""
+"If the video size cannot be detected automatically,\n"
+"you can manually specify its size in bytes.\n"
+"Leave at 0 to use automatic detection."
+msgstr ""
+"動画サイズを自動検出できない場合、\n"
+"バイト単位で手動指定できます。\n"
+"0 のままにすると自動検出を使用します。"
+
+#: src/gui.vala:699
+msgid ""
+"Enter the exact size of the video portion in bytes.\n"
+"Only needed if automatic detection fails."
+msgstr ""
+"動画部分の正確なサイズをバイト単位で入力してください。\n"
+"自動検出が失敗した場合のみ必要です。"
+
+#: src/gui.vala:709
+msgid "Video size in bytes"
+msgstr "動画サイズ（バイト）"
+
+#: src/gui.vala:733
+msgid "Repairing…"
+msgstr "修復中…"
+
+#: src/gui.vala:738
+#, c-format
+msgid "%u file repaired"
+msgid_plural "%u files repaired"
+msgstr[0] "%u 個のファイルを修復しました"
+
+#: src/gui.vala:763 src/gui.vala:790
+msgid "Extracting"
+msgstr "抽出中"
+
+#: src/gui.vala:809 src/gui.vala:827
+msgid "Repairing"
+msgstr "修復中"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1,0 +1,261 @@
+# Korean translations for live-photo-conv package.
+# Copyright (C) 2026 THE live-photo-conv'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the live-photo-conv package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: live-photo-conv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"PO-Revision-Date: 2026-05-04 14:06+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/gui.vala:64
+#, c-format
+msgid "%u file selected"
+msgid_plural "%u files selected"
+msgstr[0] "%u개 파일 선택됨"
+
+#: src/gui.vala:294 src/gui.vala:404
+msgid "Live Photo Converter"
+msgstr "Live Photo 변환기"
+
+#: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
+msgid "Make Live Photo"
+msgstr "Live Photo 만들기"
+
+#: src/gui.vala:312 src/gui.vala:319 src/gui.vala:636 src/gui.vala:639
+msgid "Extract"
+msgstr "추출"
+
+#: src/gui.vala:315 src/gui.vala:320 src/gui.vala:737 src/gui.vala:740
+msgid "Repair"
+msgstr "복구"
+
+#: src/gui.vala:318
+msgid "Make"
+msgstr "만들기"
+
+#: src/gui.vala:328
+msgid "Follow System"
+msgstr "시스템 따르기"
+
+#: src/gui.vala:329
+msgid "Light"
+msgstr "라이트"
+
+#: src/gui.vala:330
+msgid "Dark"
+msgstr "다크"
+
+#: src/gui.vala:334
+msgid "Appearance"
+msgstr "외관"
+
+#: src/gui.vala:335
+msgid "About"
+msgstr "정보"
+
+#: src/gui.vala:473
+msgid "Source Files"
+msgstr "원본 파일"
+
+#: src/gui.vala:474
+msgid "Provide a video file (required) and a static image."
+msgstr "비디오 파일(필수)과 정적 이미지를 제공하세요."
+
+#: src/gui.vala:486
+msgid "Video"
+msgstr "비디오"
+
+#: src/gui.vala:490
+msgid ""
+"Drop video here\n"
+"or click to browse"
+msgstr ""
+"비디오를 여기에 드롭\n"
+"또는 클릭하여 찾아보기"
+
+#: src/gui.vala:503
+msgid "Main Image"
+msgstr "메인 이미지"
+
+#: src/gui.vala:507
+msgid ""
+"Drop image here\n"
+"or click to browse"
+msgstr ""
+"이미지를 여기에 드롭\n"
+"또는 클릭하여 찾아보기"
+
+#: src/gui.vala:518
+msgid "Options"
+msgstr "옵션"
+
+#: src/gui.vala:520
+msgid "Export metadata"
+msgstr "메타데이터 내보내기"
+
+#: src/gui.vala:531
+msgid "Save Live Photo As"
+msgstr "Live Photo 저장"
+
+#: src/gui.vala:545
+msgid "Processing…"
+msgstr "처리 중…"
+
+#: src/gui.vala:560
+msgid "Live photo created"
+msgstr "Live Photo가 생성되었습니다"
+
+#: src/gui.vala:563 src/gui.vala:640 src/gui.vala:741
+#, c-format
+msgid "Error: %s"
+msgstr "오류: %s"
+
+#: src/gui.vala:577 src/gui.vala:654
+msgid "Live Photo"
+msgstr "Live Photo"
+
+#: src/gui.vala:578
+msgid "Select the live photo file to extract from."
+msgstr "추출할 Live Photo 파일을 선택하세요."
+
+#: src/gui.vala:580 src/gui.vala:657
+msgid ""
+"Drop live photo file here\n"
+"or click to browse"
+msgstr ""
+"Live Photo 파일을 여기에 드롭\n"
+"또는 클릭하여 찾아보기"
+
+#: src/gui.vala:593
+msgid "Export Items"
+msgstr "내보내기 항목"
+
+#: src/gui.vala:594
+msgid "Choose what to extract from the live photo."
+msgstr "Live Photo에서 추출할 항목을 선택하세요."
+
+#: src/gui.vala:596
+msgid "Export Main Image"
+msgstr "메인 이미지 내보내기"
+
+#: src/gui.vala:597
+msgid "Export Video"
+msgstr "비디오 내보내기"
+
+#: src/gui.vala:598
+msgid "Export Frames as Photos"
+msgstr "프레임을 사진으로 내보내기"
+
+#: src/gui.vala:599
+msgid "Export Long Exposure Photo"
+msgstr "장노출 사진 내보내기"
+
+#: src/gui.vala:600
+msgid "Image Format"
+msgstr "이미지 형식"
+
+#: src/gui.vala:600
+msgid "auto"
+msgstr "자동"
+
+#: src/gui.vala:609 src/gui.vala:726
+msgid "Please select a live photo file first"
+msgstr "먼저 Live Photo 파일을 선택하세요"
+
+#: src/gui.vala:614
+msgid "Select Output Directory"
+msgstr "출력 디렉토리 선택"
+
+#: src/gui.vala:629
+msgid "Extracting…"
+msgstr "추출 중…"
+
+#: src/gui.vala:637
+#, c-format
+msgid "%u file extracted"
+msgid_plural "%u files extracted"
+msgstr[0] "%u개 파일 추출됨"
+
+#: src/gui.vala:655
+msgid "Select the live photo file to repair its XMP metadata."
+msgstr "XMP 메타데이터를 복구할 Live Photo 파일을 선택하세요."
+
+#: src/gui.vala:670
+msgid "Repair Options"
+msgstr "복구 옵션"
+
+#: src/gui.vala:672
+msgid "Force Repair"
+msgstr "강제 복구"
+
+#: src/gui.vala:674
+msgid ""
+"If enabled, the video offset will be re-discovered by scanning\n"
+"the entire file for the MP4 header, overriding any existing\n"
+"offset value in the XMP metadata."
+msgstr ""
+"활성화하면 전체 파일을 스캔하여 MP4 헤더를\n"
+"다시 발견하고 XMP 메타데이터의 기존\n"
+"오프셋 값을 덮어씁니다."
+
+#: src/gui.vala:680
+msgid "Advanced"
+msgstr "고급"
+
+#: src/gui.vala:682
+msgid "Manual Video Size"
+msgstr "수동 비디오 크기"
+
+#: src/gui.vala:683
+msgid "Specify the size of the embedded video in bytes"
+msgstr "포함된 비디오의 크기를 바이트 단위로 지정"
+
+#: src/gui.vala:684
+msgid ""
+"If the video size cannot be detected automatically,\n"
+"you can manually specify its size in bytes.\n"
+"Leave at 0 to use automatic detection."
+msgstr ""
+"비디오 크기를 자동으로 감지할 수 없는 경우\n"
+"바이트 단위로 수동 지정할 수 있습니다.\n"
+"0으로 두면 자동 감지를 사용합니다."
+
+#: src/gui.vala:699
+msgid ""
+"Enter the exact size of the video portion in bytes.\n"
+"Only needed if automatic detection fails."
+msgstr ""
+"비디오 부분의 정확한 크기를 바이트 단위로 입력하세요.\n"
+"자동 감지가 실패한 경우에만 필요합니다."
+
+#: src/gui.vala:709
+msgid "Video size in bytes"
+msgstr "비디오 크기(바이트)"
+
+#: src/gui.vala:733
+msgid "Repairing…"
+msgstr "복구 중…"
+
+#: src/gui.vala:738
+#, c-format
+msgid "%u file repaired"
+msgid_plural "%u files repaired"
+msgstr[0] "%u개 파일 복구됨"
+
+#: src/gui.vala:763 src/gui.vala:790
+msgid "Extracting"
+msgstr "추출 중"
+
+#: src/gui.vala:809 src/gui.vala:827
+msgid "Repairing"
+msgstr "복구 중"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-photo-conv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"POT-Creation-Date: 2026-05-04 17:44+0800\n"
 "PO-Revision-Date: 2026-05-04 14:06+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -22,10 +22,6 @@ msgstr ""
 msgid "%u file selected"
 msgid_plural "%u files selected"
 msgstr[0] "%u개 파일 선택됨"
-
-#: src/gui.vala:294 src/gui.vala:404
-msgid "Live Photo Converter"
-msgstr "Live Photo 변환기"
 
 #: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
 msgid "Make Live Photo"
@@ -259,3 +255,6 @@ msgstr "추출 중"
 #: src/gui.vala:809 src/gui.vala:827
 msgid "Repairing"
 msgstr "복구 중"
+
+#~ msgid "Live Photo Converter"
+#~ msgstr "Live Photo 변환기"

--- a/po/live-photo-conv.pot
+++ b/po/live-photo-conv.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-photo-conv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"POT-Creation-Date: 2026-05-04 17:44+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,10 +24,6 @@ msgid "%u file selected"
 msgid_plural "%u files selected"
 msgstr[0] ""
 msgstr[1] ""
-
-#: src/gui.vala:294 src/gui.vala:404
-msgid "Live Photo Converter"
-msgstr ""
 
 #: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
 msgid "Make Live Photo"

--- a/po/live-photo-conv.pot
+++ b/po/live-photo-conv.pot
@@ -1,0 +1,251 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the live-photo-conv package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: live-photo-conv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: src/gui.vala:64
+#, c-format
+msgid "%u file selected"
+msgid_plural "%u files selected"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/gui.vala:294 src/gui.vala:404
+msgid "Live Photo Converter"
+msgstr ""
+
+#: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
+msgid "Make Live Photo"
+msgstr ""
+
+#: src/gui.vala:312 src/gui.vala:319 src/gui.vala:636 src/gui.vala:639
+msgid "Extract"
+msgstr ""
+
+#: src/gui.vala:315 src/gui.vala:320 src/gui.vala:737 src/gui.vala:740
+msgid "Repair"
+msgstr ""
+
+#: src/gui.vala:318
+msgid "Make"
+msgstr ""
+
+#: src/gui.vala:328
+msgid "Follow System"
+msgstr ""
+
+#: src/gui.vala:329
+msgid "Light"
+msgstr ""
+
+#: src/gui.vala:330
+msgid "Dark"
+msgstr ""
+
+#: src/gui.vala:334
+msgid "Appearance"
+msgstr ""
+
+#: src/gui.vala:335
+msgid "About"
+msgstr ""
+
+#: src/gui.vala:473
+msgid "Source Files"
+msgstr ""
+
+#: src/gui.vala:474
+msgid "Provide a video file (required) and a static image."
+msgstr ""
+
+#: src/gui.vala:486
+msgid "Video"
+msgstr ""
+
+#: src/gui.vala:490
+msgid ""
+"Drop video here\n"
+"or click to browse"
+msgstr ""
+
+#: src/gui.vala:503
+msgid "Main Image"
+msgstr ""
+
+#: src/gui.vala:507
+msgid ""
+"Drop image here\n"
+"or click to browse"
+msgstr ""
+
+#: src/gui.vala:518
+msgid "Options"
+msgstr ""
+
+#: src/gui.vala:520
+msgid "Export metadata"
+msgstr ""
+
+#: src/gui.vala:531
+msgid "Save Live Photo As"
+msgstr ""
+
+#: src/gui.vala:545
+msgid "Processing…"
+msgstr ""
+
+#: src/gui.vala:560
+msgid "Live photo created"
+msgstr ""
+
+#: src/gui.vala:563 src/gui.vala:640 src/gui.vala:741
+#, c-format
+msgid "Error: %s"
+msgstr ""
+
+#: src/gui.vala:577 src/gui.vala:654
+msgid "Live Photo"
+msgstr ""
+
+#: src/gui.vala:578
+msgid "Select the live photo file to extract from."
+msgstr ""
+
+#: src/gui.vala:580 src/gui.vala:657
+msgid ""
+"Drop live photo file here\n"
+"or click to browse"
+msgstr ""
+
+#: src/gui.vala:593
+msgid "Export Items"
+msgstr ""
+
+#: src/gui.vala:594
+msgid "Choose what to extract from the live photo."
+msgstr ""
+
+#: src/gui.vala:596
+msgid "Export Main Image"
+msgstr ""
+
+#: src/gui.vala:597
+msgid "Export Video"
+msgstr ""
+
+#: src/gui.vala:598
+msgid "Export Frames as Photos"
+msgstr ""
+
+#: src/gui.vala:599
+msgid "Export Long Exposure Photo"
+msgstr ""
+
+#: src/gui.vala:600
+msgid "Image Format"
+msgstr ""
+
+#: src/gui.vala:600
+msgid "auto"
+msgstr ""
+
+#: src/gui.vala:609 src/gui.vala:726
+msgid "Please select a live photo file first"
+msgstr ""
+
+#: src/gui.vala:614
+msgid "Select Output Directory"
+msgstr ""
+
+#: src/gui.vala:629
+msgid "Extracting…"
+msgstr ""
+
+#: src/gui.vala:637
+#, c-format
+msgid "%u file extracted"
+msgid_plural "%u files extracted"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/gui.vala:655
+msgid "Select the live photo file to repair its XMP metadata."
+msgstr ""
+
+#: src/gui.vala:670
+msgid "Repair Options"
+msgstr ""
+
+#: src/gui.vala:672
+msgid "Force Repair"
+msgstr ""
+
+#: src/gui.vala:674
+msgid ""
+"If enabled, the video offset will be re-discovered by scanning\n"
+"the entire file for the MP4 header, overriding any existing\n"
+"offset value in the XMP metadata."
+msgstr ""
+
+#: src/gui.vala:680
+msgid "Advanced"
+msgstr ""
+
+#: src/gui.vala:682
+msgid "Manual Video Size"
+msgstr ""
+
+#: src/gui.vala:683
+msgid "Specify the size of the embedded video in bytes"
+msgstr ""
+
+#: src/gui.vala:684
+msgid ""
+"If the video size cannot be detected automatically,\n"
+"you can manually specify its size in bytes.\n"
+"Leave at 0 to use automatic detection."
+msgstr ""
+
+#: src/gui.vala:699
+msgid ""
+"Enter the exact size of the video portion in bytes.\n"
+"Only needed if automatic detection fails."
+msgstr ""
+
+#: src/gui.vala:709
+msgid "Video size in bytes"
+msgstr ""
+
+#: src/gui.vala:733
+msgid "Repairing…"
+msgstr ""
+
+#: src/gui.vala:738
+#, c-format
+msgid "%u file repaired"
+msgid_plural "%u files repaired"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/gui.vala:763 src/gui.vala:790
+msgid "Extracting"
+msgstr ""
+
+#: src/gui.vala:809 src/gui.vala:827
+msgid "Repairing"
+msgstr ""

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,4 @@
+i18n.gettext(meson.project_name(),
+    args: '--directory=' + meson.project_source_root(),
+    preset: 'glib'
+)

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,0 +1,265 @@
+# Portuguese translations for live-photo-conv package.
+# Copyright (C) 2026 THE live-photo-conv'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the live-photo-conv package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: live-photo-conv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"PO-Revision-Date: 2026-05-04 14:06+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: src/gui.vala:64
+#, c-format
+msgid "%u file selected"
+msgid_plural "%u files selected"
+msgstr[0] "%u arquivo selecionado"
+msgstr[1] "%u arquivos selecionados"
+
+#: src/gui.vala:294 src/gui.vala:404
+msgid "Live Photo Converter"
+msgstr "Conversor de Live Photo"
+
+#: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
+msgid "Make Live Photo"
+msgstr "Criar Live Photo"
+
+#: src/gui.vala:312 src/gui.vala:319 src/gui.vala:636 src/gui.vala:639
+msgid "Extract"
+msgstr "Extrair"
+
+#: src/gui.vala:315 src/gui.vala:320 src/gui.vala:737 src/gui.vala:740
+msgid "Repair"
+msgstr "Reparar"
+
+#: src/gui.vala:318
+msgid "Make"
+msgstr "Criar"
+
+#: src/gui.vala:328
+msgid "Follow System"
+msgstr "Seguir sistema"
+
+#: src/gui.vala:329
+msgid "Light"
+msgstr "Claro"
+
+#: src/gui.vala:330
+msgid "Dark"
+msgstr "Escuro"
+
+#: src/gui.vala:334
+msgid "Appearance"
+msgstr "Aparência"
+
+#: src/gui.vala:335
+msgid "About"
+msgstr "Sobre"
+
+#: src/gui.vala:473
+msgid "Source Files"
+msgstr "Arquivos de origem"
+
+#: src/gui.vala:474
+msgid "Provide a video file (required) and a static image."
+msgstr "Forneça um arquivo de vídeo (obrigatório) e uma imagem estática."
+
+#: src/gui.vala:486
+msgid "Video"
+msgstr "Vídeo"
+
+#: src/gui.vala:490
+msgid ""
+"Drop video here\n"
+"or click to browse"
+msgstr ""
+"Solte o vídeo aqui\n"
+"ou clique para procurar"
+
+#: src/gui.vala:503
+msgid "Main Image"
+msgstr "Imagem principal"
+
+#: src/gui.vala:507
+msgid ""
+"Drop image here\n"
+"or click to browse"
+msgstr ""
+"Solte a imagem aqui\n"
+"ou clique para procurar"
+
+#: src/gui.vala:518
+msgid "Options"
+msgstr "Opções"
+
+#: src/gui.vala:520
+msgid "Export metadata"
+msgstr "Exportar metadados"
+
+#: src/gui.vala:531
+msgid "Save Live Photo As"
+msgstr "Salvar Live Photo como"
+
+#: src/gui.vala:545
+msgid "Processing…"
+msgstr "Processando…"
+
+#: src/gui.vala:560
+msgid "Live photo created"
+msgstr "Live Photo criada"
+
+#: src/gui.vala:563 src/gui.vala:640 src/gui.vala:741
+#, c-format
+msgid "Error: %s"
+msgstr "Erro: %s"
+
+#: src/gui.vala:577 src/gui.vala:654
+msgid "Live Photo"
+msgstr "Live Photo"
+
+#: src/gui.vala:578
+msgid "Select the live photo file to extract from."
+msgstr "Selecione o arquivo Live Photo para extrair."
+
+#: src/gui.vala:580 src/gui.vala:657
+msgid ""
+"Drop live photo file here\n"
+"or click to browse"
+msgstr ""
+"Solte o arquivo Live Photo aqui\n"
+"ou clique para procurar"
+
+#: src/gui.vala:593
+msgid "Export Items"
+msgstr "Itens de exportação"
+
+#: src/gui.vala:594
+msgid "Choose what to extract from the live photo."
+msgstr "Escolha o que extrair da Live Photo."
+
+#: src/gui.vala:596
+msgid "Export Main Image"
+msgstr "Exportar imagem principal"
+
+#: src/gui.vala:597
+msgid "Export Video"
+msgstr "Exportar vídeo"
+
+#: src/gui.vala:598
+msgid "Export Frames as Photos"
+msgstr "Exportar quadros como fotos"
+
+#: src/gui.vala:599
+msgid "Export Long Exposure Photo"
+msgstr "Exportar foto de longa exposição"
+
+#: src/gui.vala:600
+msgid "Image Format"
+msgstr "Formato de imagem"
+
+#: src/gui.vala:600
+msgid "auto"
+msgstr "automático"
+
+#: src/gui.vala:609 src/gui.vala:726
+msgid "Please select a live photo file first"
+msgstr "Selecione um arquivo Live Photo primeiro"
+
+#: src/gui.vala:614
+msgid "Select Output Directory"
+msgstr "Selecionar diretório de saída"
+
+#: src/gui.vala:629
+msgid "Extracting…"
+msgstr "Extraindo…"
+
+#: src/gui.vala:637
+#, c-format
+msgid "%u file extracted"
+msgid_plural "%u files extracted"
+msgstr[0] "%u arquivo extraído"
+msgstr[1] "%u arquivos extraídos"
+
+#: src/gui.vala:655
+msgid "Select the live photo file to repair its XMP metadata."
+msgstr "Selecione o arquivo Live Photo para reparar seus metadados XMP."
+
+#: src/gui.vala:670
+msgid "Repair Options"
+msgstr "Opções de reparo"
+
+#: src/gui.vala:672
+msgid "Force Repair"
+msgstr "Forçar reparo"
+
+#: src/gui.vala:674
+msgid ""
+"If enabled, the video offset will be re-discovered by scanning\n"
+"the entire file for the MP4 header, overriding any existing\n"
+"offset value in the XMP metadata."
+msgstr ""
+"Se ativado, o deslocamento do vídeo será redescoberto\n"
+"varrendo todo o arquivo em busca do cabeçalho MP4,\n"
+"substituindo qualquer valor de deslocamento existente\n"
+"nos metadados XMP."
+
+#: src/gui.vala:680
+msgid "Advanced"
+msgstr "Avançado"
+
+#: src/gui.vala:682
+msgid "Manual Video Size"
+msgstr "Tamanho manual do vídeo"
+
+#: src/gui.vala:683
+msgid "Specify the size of the embedded video in bytes"
+msgstr "Especificar o tamanho do vídeo incorporado em bytes"
+
+#: src/gui.vala:684
+msgid ""
+"If the video size cannot be detected automatically,\n"
+"you can manually specify its size in bytes.\n"
+"Leave at 0 to use automatic detection."
+msgstr ""
+"Se o tamanho do vídeo não puder ser detectado automaticamente,\n"
+"você pode especificar manualmente seu tamanho em bytes.\n"
+"Deixe em 0 para usar a detecção automática."
+
+#: src/gui.vala:699
+msgid ""
+"Enter the exact size of the video portion in bytes.\n"
+"Only needed if automatic detection fails."
+msgstr ""
+"Insira o tamanho exato da parte do vídeo em bytes.\n"
+"Necessário apenas se a detecção automática falhar."
+
+#: src/gui.vala:709
+msgid "Video size in bytes"
+msgstr "Tamanho do vídeo em bytes"
+
+#: src/gui.vala:733
+msgid "Repairing…"
+msgstr "Reparando…"
+
+#: src/gui.vala:738
+#, c-format
+msgid "%u file repaired"
+msgid_plural "%u files repaired"
+msgstr[0] "%u arquivo reparado"
+msgstr[1] "%u arquivos reparados"
+
+#: src/gui.vala:763 src/gui.vala:790
+msgid "Extracting"
+msgstr "Extraindo"
+
+#: src/gui.vala:809 src/gui.vala:827
+msgid "Repairing"
+msgstr "Reparando"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-photo-conv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"POT-Creation-Date: 2026-05-04 17:44+0800\n"
 "PO-Revision-Date: 2026-05-04 14:06+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -23,10 +23,6 @@ msgid "%u file selected"
 msgid_plural "%u files selected"
 msgstr[0] "%u arquivo selecionado"
 msgstr[1] "%u arquivos selecionados"
-
-#: src/gui.vala:294 src/gui.vala:404
-msgid "Live Photo Converter"
-msgstr "Conversor de Live Photo"
 
 #: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
 msgid "Make Live Photo"
@@ -263,3 +259,6 @@ msgstr "Extraindo"
 #: src/gui.vala:809 src/gui.vala:827
 msgid "Repairing"
 msgstr "Reparando"
+
+#~ msgid "Live Photo Converter"
+#~ msgstr "Conversor de Live Photo"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-photo-conv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"POT-Creation-Date: 2026-05-04 17:44+0800\n"
 "PO-Revision-Date: 2026-05-04 14:06+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -25,10 +25,6 @@ msgid_plural "%u files selected"
 msgstr[0] "%u файл выбран"
 msgstr[1] "%u файла выбрано"
 msgstr[2] "%u файлов выбрано"
-
-#: src/gui.vala:294 src/gui.vala:404
-msgid "Live Photo Converter"
-msgstr "Конвертер Live Photo"
 
 #: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
 msgid "Make Live Photo"
@@ -267,3 +263,6 @@ msgstr "Извлечение"
 #: src/gui.vala:809 src/gui.vala:827
 msgid "Repairing"
 msgstr "Восстановление"
+
+#~ msgid "Live Photo Converter"
+#~ msgstr "Конвертер Live Photo"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,0 +1,269 @@
+# Russian translations for live-photo-conv package.
+# Copyright (C) 2026 THE live-photo-conv'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the live-photo-conv package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: live-photo-conv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"PO-Revision-Date: 2026-05-04 14:06+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: src/gui.vala:64
+#, c-format
+msgid "%u file selected"
+msgid_plural "%u files selected"
+msgstr[0] "%u файл выбран"
+msgstr[1] "%u файла выбрано"
+msgstr[2] "%u файлов выбрано"
+
+#: src/gui.vala:294 src/gui.vala:404
+msgid "Live Photo Converter"
+msgstr "Конвертер Live Photo"
+
+#: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
+msgid "Make Live Photo"
+msgstr "Создать Live Photo"
+
+#: src/gui.vala:312 src/gui.vala:319 src/gui.vala:636 src/gui.vala:639
+msgid "Extract"
+msgstr "Извлечь"
+
+#: src/gui.vala:315 src/gui.vala:320 src/gui.vala:737 src/gui.vala:740
+msgid "Repair"
+msgstr "Восстановить"
+
+#: src/gui.vala:318
+msgid "Make"
+msgstr "Создать"
+
+#: src/gui.vala:328
+msgid "Follow System"
+msgstr "Как в системе"
+
+#: src/gui.vala:329
+msgid "Light"
+msgstr "Светлая"
+
+#: src/gui.vala:330
+msgid "Dark"
+msgstr "Тёмная"
+
+#: src/gui.vala:334
+msgid "Appearance"
+msgstr "Оформление"
+
+#: src/gui.vala:335
+msgid "About"
+msgstr "О программе"
+
+#: src/gui.vala:473
+msgid "Source Files"
+msgstr "Исходные файлы"
+
+#: src/gui.vala:474
+msgid "Provide a video file (required) and a static image."
+msgstr "Укажите видеофайл (обязательно) и статическое изображение."
+
+#: src/gui.vala:486
+msgid "Video"
+msgstr "Видео"
+
+#: src/gui.vala:490
+msgid ""
+"Drop video here\n"
+"or click to browse"
+msgstr ""
+"Перетащите видео сюда\n"
+"или нажмите для выбора"
+
+#: src/gui.vala:503
+msgid "Main Image"
+msgstr "Основное изображение"
+
+#: src/gui.vala:507
+msgid ""
+"Drop image here\n"
+"or click to browse"
+msgstr ""
+"Перетащите изображение сюда\n"
+"или нажмите для выбора"
+
+#: src/gui.vala:518
+msgid "Options"
+msgstr "Параметры"
+
+#: src/gui.vala:520
+msgid "Export metadata"
+msgstr "Экспорт метаданных"
+
+#: src/gui.vala:531
+msgid "Save Live Photo As"
+msgstr "Сохранить Live Photo как"
+
+#: src/gui.vala:545
+msgid "Processing…"
+msgstr "Обработка…"
+
+#: src/gui.vala:560
+msgid "Live photo created"
+msgstr "Live Photo создана"
+
+#: src/gui.vala:563 src/gui.vala:640 src/gui.vala:741
+#, c-format
+msgid "Error: %s"
+msgstr "Ошибка: %s"
+
+#: src/gui.vala:577 src/gui.vala:654
+msgid "Live Photo"
+msgstr "Live Photo"
+
+#: src/gui.vala:578
+msgid "Select the live photo file to extract from."
+msgstr "Выберите файл Live Photo для извлечения."
+
+#: src/gui.vala:580 src/gui.vala:657
+msgid ""
+"Drop live photo file here\n"
+"or click to browse"
+msgstr ""
+"Перетащите файл Live Photo сюда\n"
+"или нажмите для выбора"
+
+#: src/gui.vala:593
+msgid "Export Items"
+msgstr "Элементы экспорта"
+
+#: src/gui.vala:594
+msgid "Choose what to extract from the live photo."
+msgstr "Выберите, что извлечь из Live Photo."
+
+#: src/gui.vala:596
+msgid "Export Main Image"
+msgstr "Экспорт основного изображения"
+
+#: src/gui.vala:597
+msgid "Export Video"
+msgstr "Экспорт видео"
+
+#: src/gui.vala:598
+msgid "Export Frames as Photos"
+msgstr "Экспорт кадров как фото"
+
+#: src/gui.vala:599
+msgid "Export Long Exposure Photo"
+msgstr "Экспорт фото с длинной выдержкой"
+
+#: src/gui.vala:600
+msgid "Image Format"
+msgstr "Формат изображения"
+
+#: src/gui.vala:600
+msgid "auto"
+msgstr "авто"
+
+#: src/gui.vala:609 src/gui.vala:726
+msgid "Please select a live photo file first"
+msgstr "Сначала выберите файл Live Photo"
+
+#: src/gui.vala:614
+msgid "Select Output Directory"
+msgstr "Выберите выходной каталог"
+
+#: src/gui.vala:629
+msgid "Extracting…"
+msgstr "Извлечение…"
+
+#: src/gui.vala:637
+#, c-format
+msgid "%u file extracted"
+msgid_plural "%u files extracted"
+msgstr[0] "%u файл извлечён"
+msgstr[1] "%u файла извлечено"
+msgstr[2] "%u файлов извлечено"
+
+#: src/gui.vala:655
+msgid "Select the live photo file to repair its XMP metadata."
+msgstr "Выберите файл Live Photo для восстановления метаданных XMP."
+
+#: src/gui.vala:670
+msgid "Repair Options"
+msgstr "Параметры восстановления"
+
+#: src/gui.vala:672
+msgid "Force Repair"
+msgstr "Принудительное восстановление"
+
+#: src/gui.vala:674
+msgid ""
+"If enabled, the video offset will be re-discovered by scanning\n"
+"the entire file for the MP4 header, overriding any existing\n"
+"offset value in the XMP metadata."
+msgstr ""
+"Если включено, смещение видео будет определено заново\n"
+"путём сканирования всего файла на наличие заголовка MP4,\n"
+"перезаписывая существующее значение смещения\n"
+"в метаданных XMP."
+
+#: src/gui.vala:680
+msgid "Advanced"
+msgstr "Дополнительно"
+
+#: src/gui.vala:682
+msgid "Manual Video Size"
+msgstr "Размер видео вручную"
+
+#: src/gui.vala:683
+msgid "Specify the size of the embedded video in bytes"
+msgstr "Укажите размер встроенного видео в байтах"
+
+#: src/gui.vala:684
+msgid ""
+"If the video size cannot be detected automatically,\n"
+"you can manually specify its size in bytes.\n"
+"Leave at 0 to use automatic detection."
+msgstr ""
+"Если размер видео не может быть определён автоматически,\n"
+"вы можете указать его размер в байтах вручную.\n"
+"Оставьте 0 для автоматического определения."
+
+#: src/gui.vala:699
+msgid ""
+"Enter the exact size of the video portion in bytes.\n"
+"Only needed if automatic detection fails."
+msgstr ""
+"Введите точный размер видеочасти в байтах.\n"
+"Требуется только при сбое автоматического определения."
+
+#: src/gui.vala:709
+msgid "Video size in bytes"
+msgstr "Размер видео в байтах"
+
+#: src/gui.vala:733
+msgid "Repairing…"
+msgstr "Восстановление…"
+
+#: src/gui.vala:738
+#, c-format
+msgid "%u file repaired"
+msgid_plural "%u files repaired"
+msgstr[0] "%u файл восстановлен"
+msgstr[1] "%u файла восстановлено"
+msgstr[2] "%u файлов восстановлено"
+
+#: src/gui.vala:763 src/gui.vala:790
+msgid "Extracting"
+msgstr "Извлечение"
+
+#: src/gui.vala:809 src/gui.vala:827
+msgid "Repairing"
+msgstr "Восстановление"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,0 +1,261 @@
+# Chinese translations for live-photo-conv package.
+# Copyright (C) 2026 THE live-photo-conv'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the live-photo-conv package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: live-photo-conv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"PO-Revision-Date: 2026-05-04 14:06+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/gui.vala:64
+#, c-format
+msgid "%u file selected"
+msgid_plural "%u files selected"
+msgstr[0] "%u 个文件已选择"
+
+#: src/gui.vala:294 src/gui.vala:404
+msgid "Live Photo Converter"
+msgstr "动态照片转换器"
+
+#: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
+msgid "Make Live Photo"
+msgstr "制作动态照片"
+
+#: src/gui.vala:312 src/gui.vala:319 src/gui.vala:636 src/gui.vala:639
+msgid "Extract"
+msgstr "提取"
+
+#: src/gui.vala:315 src/gui.vala:320 src/gui.vala:737 src/gui.vala:740
+msgid "Repair"
+msgstr "修复"
+
+#: src/gui.vala:318
+msgid "Make"
+msgstr "制作"
+
+#: src/gui.vala:328
+msgid "Follow System"
+msgstr "跟随系统"
+
+#: src/gui.vala:329
+msgid "Light"
+msgstr "浅色"
+
+#: src/gui.vala:330
+msgid "Dark"
+msgstr "深色"
+
+#: src/gui.vala:334
+msgid "Appearance"
+msgstr "外观"
+
+#: src/gui.vala:335
+msgid "About"
+msgstr "关于"
+
+#: src/gui.vala:473
+msgid "Source Files"
+msgstr "源文件"
+
+#: src/gui.vala:474
+msgid "Provide a video file (required) and a static image."
+msgstr "提供视频文件（必需）和一张静态图像。"
+
+#: src/gui.vala:486
+msgid "Video"
+msgstr "视频"
+
+#: src/gui.vala:490
+msgid ""
+"Drop video here\n"
+"or click to browse"
+msgstr ""
+"将视频拖放到此处\n"
+"或点击浏览"
+
+#: src/gui.vala:503
+msgid "Main Image"
+msgstr "主图像"
+
+#: src/gui.vala:507
+msgid ""
+"Drop image here\n"
+"or click to browse"
+msgstr ""
+"将图像拖放到此处\n"
+"或点击浏览"
+
+#: src/gui.vala:518
+msgid "Options"
+msgstr "选项"
+
+#: src/gui.vala:520
+msgid "Export metadata"
+msgstr "导出元数据"
+
+#: src/gui.vala:531
+msgid "Save Live Photo As"
+msgstr "保存动态照片为"
+
+#: src/gui.vala:545
+msgid "Processing…"
+msgstr "正在处理…"
+
+#: src/gui.vala:560
+msgid "Live photo created"
+msgstr "动态照片已创建"
+
+#: src/gui.vala:563 src/gui.vala:640 src/gui.vala:741
+#, c-format
+msgid "Error: %s"
+msgstr "错误：%s"
+
+#: src/gui.vala:577 src/gui.vala:654
+msgid "Live Photo"
+msgstr "动态照片"
+
+#: src/gui.vala:578
+msgid "Select the live photo file to extract from."
+msgstr "选择要从中提取的动态照片文件。"
+
+#: src/gui.vala:580 src/gui.vala:657
+msgid ""
+"Drop live photo file here\n"
+"or click to browse"
+msgstr ""
+"将动态照片文件拖放到此处\n"
+"或点击浏览"
+
+#: src/gui.vala:593
+msgid "Export Items"
+msgstr "导出项目"
+
+#: src/gui.vala:594
+msgid "Choose what to extract from the live photo."
+msgstr "选择要从动态照片中提取的内容。"
+
+#: src/gui.vala:596
+msgid "Export Main Image"
+msgstr "导出主图像"
+
+#: src/gui.vala:597
+msgid "Export Video"
+msgstr "导出视频"
+
+#: src/gui.vala:598
+msgid "Export Frames as Photos"
+msgstr "导出帧为照片"
+
+#: src/gui.vala:599
+msgid "Export Long Exposure Photo"
+msgstr "导出长曝光照片"
+
+#: src/gui.vala:600
+msgid "Image Format"
+msgstr "图像格式"
+
+#: src/gui.vala:600
+msgid "auto"
+msgstr "自动"
+
+#: src/gui.vala:609 src/gui.vala:726
+msgid "Please select a live photo file first"
+msgstr "请先选择动态照片文件"
+
+#: src/gui.vala:614
+msgid "Select Output Directory"
+msgstr "选择输出目录"
+
+#: src/gui.vala:629
+msgid "Extracting…"
+msgstr "正在提取…"
+
+#: src/gui.vala:637
+#, c-format
+msgid "%u file extracted"
+msgid_plural "%u files extracted"
+msgstr[0] "已提取 %u 个文件"
+
+#: src/gui.vala:655
+msgid "Select the live photo file to repair its XMP metadata."
+msgstr "选择要修复 XMP 元数据的动态照片文件。"
+
+#: src/gui.vala:670
+msgid "Repair Options"
+msgstr "修复选项"
+
+#: src/gui.vala:672
+msgid "Force Repair"
+msgstr "强制修复"
+
+#: src/gui.vala:674
+msgid ""
+"If enabled, the video offset will be re-discovered by scanning\n"
+"the entire file for the MP4 header, overriding any existing\n"
+"offset value in the XMP metadata."
+msgstr ""
+"启用后，将通过扫描整个文件查找 MP4 标头\n"
+"来重新发现视频偏移量，覆盖 XMP 元数据中\n"
+"现有的偏移值。"
+
+#: src/gui.vala:680
+msgid "Advanced"
+msgstr "高级"
+
+#: src/gui.vala:682
+msgid "Manual Video Size"
+msgstr "手动指定视频大小"
+
+#: src/gui.vala:683
+msgid "Specify the size of the embedded video in bytes"
+msgstr "指定嵌入视频的大小（字节）"
+
+#: src/gui.vala:684
+msgid ""
+"If the video size cannot be detected automatically,\n"
+"you can manually specify its size in bytes.\n"
+"Leave at 0 to use automatic detection."
+msgstr ""
+"如果无法自动检测视频大小，\n"
+"您可以手动指定其字节大小。\n"
+"设置为 0 以使用自动检测。"
+
+#: src/gui.vala:699
+msgid ""
+"Enter the exact size of the video portion in bytes.\n"
+"Only needed if automatic detection fails."
+msgstr ""
+"输入视频部分的精确字节大小。\n"
+"仅在自动检测失败时需要。"
+
+#: src/gui.vala:709
+msgid "Video size in bytes"
+msgstr "视频大小（字节）"
+
+#: src/gui.vala:733
+msgid "Repairing…"
+msgstr "正在修复…"
+
+#: src/gui.vala:738
+#, c-format
+msgid "%u file repaired"
+msgid_plural "%u files repaired"
+msgstr[0] "已修复 %u 个文件"
+
+#: src/gui.vala:763 src/gui.vala:790
+msgid "Extracting"
+msgstr "正在提取"
+
+#: src/gui.vala:809 src/gui.vala:827
+msgid "Repairing"
+msgstr "正在修复"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-photo-conv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-04 17:38+0800\n"
+"POT-Creation-Date: 2026-05-04 17:44+0800\n"
 "PO-Revision-Date: 2026-05-04 14:06+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -22,10 +22,6 @@ msgstr ""
 msgid "%u file selected"
 msgid_plural "%u files selected"
 msgstr[0] "%u 个文件已选择"
-
-#: src/gui.vala:294 src/gui.vala:404
-msgid "Live Photo Converter"
-msgstr "动态照片转换器"
 
 #: src/gui.vala:309 src/gui.vala:559 src/gui.vala:562
 msgid "Make Live Photo"
@@ -259,3 +255,6 @@ msgstr "正在提取"
 #: src/gui.vala:809 src/gui.vala:827
 msgid "Repairing"
 msgstr "正在修复"
+
+#~ msgid "Live Photo Converter"
+#~ msgstr "动态照片转换器"

--- a/src/constants.vala.in
+++ b/src/constants.vala.in
@@ -15,14 +15,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
-*/
+ */
 
 namespace LivePhotoConv {
-    public const string VERSION = "@VCS_TAG@";
+    public const string VERSION = @VERSION@;
+    public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+    public const string LOCALEDIR = @LOCALEDIR@;
+
     public const string COPYRIGHT = "Copyright (C) 2024-2026 Zhou Qiankang <wszqkzqk@qq.com>";
     public const string SPDX_LICENSE_ID = "LGPL-2.1-or-later";
     public const string WEBSITE = "https://github.com/wszqkzqk/live-photo-conv";
     public const string ISSUES_URL = "https://github.com/wszqkzqk/live-photo-conv/issues";
+
     private const string LICENSE_TEXT = """
 Copyright (C) 2024-2026 Zhou Qiankang <wszqkzqk@qq.com>
 SPDX-License-Identifier: LGPL-2.1-or-later

--- a/src/gui.vala
+++ b/src/gui.vala
@@ -291,7 +291,7 @@ public class LivePhotoConv.Application : Adw.Application {
      */
     public override void activate () {
         var window = new Adw.ApplicationWindow (this) {
-            title = _("Live Photo Converter"),
+            title = "Live Photo Converter",
             default_width = 520,
             default_height = 750,
         };
@@ -401,7 +401,7 @@ public class LivePhotoConv.Application : Adw.Application {
 
     private void show_about () {
         var about = new Adw.AboutDialog () {
-            application_name = _("Live Photo Converter"),
+            application_name = "Live Photo Converter",
             application_icon = "com.github.wszqkzqk.live-photo-conv",
             developer_name = "Zhou Qiankang (wszqkzqk)",
             version = VERSION,

--- a/src/gui.vala
+++ b/src/gui.vala
@@ -61,7 +61,7 @@ private class LivePhotoConv.FileDropArea : Adw.Bin {
                 icon_image.icon_name = "emblem-documents-symbolic";
                 icon_image.opacity = 1.0;
             } else {
-                file_label.label = @"$(value.length) files selected";
+                file_label.label = ngettext ("%u file selected", "%u files selected", value.length).printf (value.length);
                 label_stack.visible_child = file_label;
                 icon_image.icon_name = "emblem-documents-symbolic";
                 icon_image.opacity = 1.0;
@@ -291,7 +291,7 @@ public class LivePhotoConv.Application : Adw.Application {
      */
     public override void activate () {
         var window = new Adw.ApplicationWindow (this) {
-            title = "Live Photo Converter",
+            title = _("Live Photo Converter"),
             default_width = 520,
             default_height = 750,
         };
@@ -306,18 +306,18 @@ public class LivePhotoConv.Application : Adw.Application {
 
         var stack = new Adw.ViewStack ();
 
-        make_button = make_action_button ("Make Live Photo");
+        make_button = make_action_button (_("Make Live Photo"));
         make_button.clicked.connect (on_make_clicked);
 
-        extract_button = make_action_button ("Extract");
+        extract_button = make_action_button (_("Extract"));
         extract_button.clicked.connect (on_extract_clicked);
 
-        repair_button = make_action_button ("Repair");
+        repair_button = make_action_button (_("Repair"));
         repair_button.clicked.connect (on_repair_clicked);
 
-        stack.add_titled_with_icon (page_with_action_button (build_make_page (), make_button), "make", "Make", "list-add-symbolic");
-        stack.add_titled_with_icon (page_with_action_button (build_extract_page (), extract_button), "extract", "Extract", "document-send-symbolic");
-        stack.add_titled_with_icon (page_with_action_button (build_repair_page (), repair_button), "repair", "Repair", "applications-utilities-symbolic");
+        stack.add_titled_with_icon (page_with_action_button (build_make_page (), make_button), "make", _("Make"), "list-add-symbolic");
+        stack.add_titled_with_icon (page_with_action_button (build_extract_page (), extract_button), "extract", _("Extract"), "document-send-symbolic");
+        stack.add_titled_with_icon (page_with_action_button (build_repair_page (), repair_button), "repair", _("Repair"), "applications-utilities-symbolic");
 
         view_switcher.stack = stack;
         stack.visible_child_name = "extract";
@@ -325,14 +325,14 @@ public class LivePhotoConv.Application : Adw.Application {
 
         var appearance_menu = new Menu ();
         var section = new Menu ();
-        section.append ("Follow System", "app.color-scheme::default");
-        section.append ("Light", "app.color-scheme::force-light");
-        section.append ("Dark", "app.color-scheme::force-dark");
+        section.append (_("Follow System"), "app.color-scheme::default");
+        section.append (_("Light"), "app.color-scheme::force-light");
+        section.append (_("Dark"), "app.color-scheme::force-dark");
         appearance_menu.append_section (null, section);
 
         var menu = new Menu ();
-        menu.append_submenu ("Appearance", appearance_menu);
-        menu.append ("About", "app.about");
+        menu.append_submenu (_("Appearance"), appearance_menu);
+        menu.append (_("About"), "app.about");
 
         var menu_button = new Gtk.MenuButton () {
             icon_name = "open-menu-symbolic",
@@ -401,7 +401,7 @@ public class LivePhotoConv.Application : Adw.Application {
 
     private void show_about () {
         var about = new Adw.AboutDialog () {
-            application_name = "Live Photo Converter",
+            application_name = _("Live Photo Converter"),
             application_icon = "com.github.wszqkzqk.live-photo-conv",
             developer_name = "Zhou Qiankang (wszqkzqk)",
             version = VERSION,
@@ -470,8 +470,8 @@ public class LivePhotoConv.Application : Adw.Application {
             margin_top = 6,
         };
 
-        var files_group = make_group ("Source Files",
-            "Provide a video file (required) and a static image.");
+        var files_group = make_group (_("Source Files"),
+            _("Provide a video file (required) and a static image."));
 
         // Side-by-side drop areas: Video | Main Image
         var drop_row = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
@@ -483,11 +483,11 @@ public class LivePhotoConv.Application : Adw.Application {
         };
 
         var video_col = new Gtk.Box (Gtk.Orientation.VERTICAL, 4);
-        video_col.append (new Gtk.Label ("Video") {
+        video_col.append (new Gtk.Label (_("Video")) {
             xalign = 0,
             css_classes = { "heading" },
         });
-        make_video_area = new FileDropArea ("Drop video here\nor click to browse", "folder-videos-symbolic", {"video/*"}) {
+        make_video_area = new FileDropArea (_("Drop video here\nor click to browse"), "folder-videos-symbolic", {"video/*"}) {
             max_files = 1,
             vexpand = true,
             valign = Gtk.Align.FILL,
@@ -500,11 +500,11 @@ public class LivePhotoConv.Application : Adw.Application {
         drop_row.append (video_col);
 
         var image_col = new Gtk.Box (Gtk.Orientation.VERTICAL, 4);
-        image_col.append (new Gtk.Label ("Main Image") {
+        image_col.append (new Gtk.Label (_("Main Image")) {
             xalign = 0,
             css_classes = { "heading" },
         });
-        make_image_area = new FileDropArea ("Drop image here\nor click to browse", "folder-pictures-symbolic", {"image/*"}) {
+        make_image_area = new FileDropArea (_("Drop image here\nor click to browse"), "folder-pictures-symbolic", {"image/*"}) {
             max_files = 1,
             vexpand = true,
             valign = Gtk.Align.FILL,
@@ -515,9 +515,9 @@ public class LivePhotoConv.Application : Adw.Application {
         files_group.add (new Adw.ActionRow () { child = drop_row });
         box.append (files_group);
 
-        var options_group = make_group ("Options");
+        var options_group = make_group (_("Options"));
         make_export_metadata_check = null;
-        options_group.add (make_check_row ("Export metadata", out make_export_metadata_check, true));
+        options_group.add (make_check_row (_("Export metadata"), out make_export_metadata_check, true));
         box.append (options_group);
 
         return box;
@@ -528,7 +528,7 @@ public class LivePhotoConv.Application : Adw.Application {
         if (video_file == null) return;
 
         var dialog = new Gtk.FileDialog () {
-            title = "Save Live Photo As",
+            title = _("Save Live Photo As"),
             initial_name = "MVIMG_live_photo.jpg",
         };
         dialog.save.begin (active_window, null, (obj, res) => {
@@ -542,7 +542,7 @@ public class LivePhotoConv.Application : Adw.Application {
                 var output_path = output_file.get_path ();
                 bool export_metadata = make_export_metadata_check.active;
 
-                start_work (make_button, "Processing…");
+                start_work (make_button, _("Processing…"));
 
 #if ENABLE_GST
                 var maker = new LiveMakerGst (video_path, image_path, output_path) {
@@ -556,11 +556,11 @@ public class LivePhotoConv.Application : Adw.Application {
                 maker.export_async.begin ((obj, res2) => {
                     try {
                         maker.export_async.end (res2);
-                        end_work (make_button, "Make Live Photo", make_video_area.files.length > 0);
-                        show_toast ("Live photo created");
+                        end_work (make_button, _("Make Live Photo"), make_video_area.files.length > 0);
+                        show_toast (_("Live photo created"));
                     } catch (Error e) {
-                        end_work (make_button, "Make Live Photo", make_video_area.files.length > 0);
-                        show_toast (@"Error: $(e.message)");
+                        end_work (make_button, _("Make Live Photo"), make_video_area.files.length > 0);
+                        show_toast (_("Error: %s").printf (e.message));
                     }
                 });
             } catch {}
@@ -574,10 +574,10 @@ public class LivePhotoConv.Application : Adw.Application {
             margin_top = 6,
         };
 
-        var files_group = make_group ("Live Photo",
-            "Select the live photo file to extract from.");
+        var files_group = make_group (_("Live Photo"),
+            _("Select the live photo file to extract from."));
 
-        extract_live_photo_area = new FileDropArea ("Drop live photo file here\nor click to browse", "camera-photo-symbolic", {"image/*"}) {
+        extract_live_photo_area = new FileDropArea (_("Drop live photo file here\nor click to browse"), "camera-photo-symbolic", {"image/*"}) {
             margin_start = 12,
             margin_end = 12,
             margin_top = 12,
@@ -590,14 +590,14 @@ public class LivePhotoConv.Application : Adw.Application {
         files_group.add (new Adw.ActionRow () { child = extract_live_photo_area });
         box.append (files_group);
 
-        var exports_group = make_group ("Export Items",
-            "Choose what to extract from the live photo.");
+        var exports_group = make_group (_("Export Items"),
+            _("Choose what to extract from the live photo."));
 
-        exports_group.add (make_check_row ("Export Main Image", out extract_main_image_check, true));
-        exports_group.add (make_check_row ("Export Video", out extract_video_check, true));
-        exports_group.add (make_check_row ("Export Frames as Photos", out extract_frames_check, false));
-        exports_group.add (make_check_row ("Export Long Exposure Photo", out extract_long_exposure_check, false));
-        exports_group.add (make_entry_row ("Image Format", out extract_img_format_entry, "auto"));
+        exports_group.add (make_check_row (_("Export Main Image"), out extract_main_image_check, true));
+        exports_group.add (make_check_row (_("Export Video"), out extract_video_check, true));
+        exports_group.add (make_check_row (_("Export Frames as Photos"), out extract_frames_check, false));
+        exports_group.add (make_check_row (_("Export Long Exposure Photo"), out extract_long_exposure_check, false));
+        exports_group.add (make_entry_row (_("Image Format"), out extract_img_format_entry, _("auto")));
         box.append (exports_group);
 
         return box;
@@ -606,12 +606,12 @@ public class LivePhotoConv.Application : Adw.Application {
     private void on_extract_clicked () {
         var files = extract_live_photo_area.files;
         if (files.length == 0) {
-            show_toast ("Please select a live photo file first");
+            show_toast (_("Please select a live photo file first"));
             return;
         }
 
         var dialog = new Gtk.FileDialog () {
-            title = "Select Output Directory",
+            title = _("Select Output Directory"),
         };
         dialog.select_folder.begin (active_window, null, (obj, res) => {
             try {
@@ -626,18 +626,18 @@ public class LivePhotoConv.Application : Adw.Application {
                 string? img_format = extract_img_format_entry.text.strip ();
                 if (img_format == "") img_format = null;
 
-                start_work (extract_button, "Extracting…");
+                start_work (extract_button, _("Extracting…"));
                 extract_batch_async.begin (files, dest_dir,
                     do_image, do_video, do_long, do_frames, img_format,
                     extract_button,
                     (obj, res2) => {
                         try {
                             extract_batch_async.end (res2);
-                            end_work (extract_button, "Extract", extract_live_photo_area.files.length > 0);
-                            show_toast (@"$(files.length) file(s) extracted");
+                            end_work (extract_button, _("Extract"), extract_live_photo_area.files.length > 0);
+                            show_toast (ngettext ("%u file extracted", "%u files extracted", (uint) files.length).printf ((uint) files.length));
                         } catch (Error e) {
-                            end_work (extract_button, "Extract", extract_live_photo_area.files.length > 0);
-                            show_toast (@"Error: $(e.message)");
+                            end_work (extract_button, _("Extract"), extract_live_photo_area.files.length > 0);
+                            show_toast (_("Error: %s").printf (e.message));
                         }
                     });
             } catch {}
@@ -651,10 +651,10 @@ public class LivePhotoConv.Application : Adw.Application {
             margin_top = 6,
         };
 
-        var files_group = make_group ("Live Photo",
-            "Select the live photo file to repair its XMP metadata.");
+        var files_group = make_group (_("Live Photo"),
+            _("Select the live photo file to repair its XMP metadata."));
 
-        repair_live_photo_area = new FileDropArea ("Drop live photo file here\nor click to browse", "camera-photo-symbolic", {"image/*"}) {
+        repair_live_photo_area = new FileDropArea (_("Drop live photo file here\nor click to browse"), "camera-photo-symbolic", {"image/*"}) {
             margin_start = 12,
             margin_end = 12,
             margin_top = 12,
@@ -667,23 +667,23 @@ public class LivePhotoConv.Application : Adw.Application {
         files_group.add (new Adw.ActionRow () { child = repair_live_photo_area });
         box.append (files_group);
 
-        var options_group = make_group ("Repair Options");
+        var options_group = make_group (_("Repair Options"));
 
-        options_group.add (make_check_row ("Force Repair",
+        options_group.add (make_check_row (_("Force Repair"),
             out repair_force_check, false,
-            "If enabled, the video offset will be re-discovered by scanning\n"
+            _("If enabled, the video offset will be re-discovered by scanning\n"
             + "the entire file for the MP4 header, overriding any existing\n"
-            + "offset value in the XMP metadata."));
+            + "offset value in the XMP metadata.")));
 
         box.append (options_group);
 
-        var advanced_group = make_group ("Advanced");
+        var advanced_group = make_group (_("Advanced"));
         var expander = new Adw.ExpanderRow () {
-            title = "Manual Video Size",
-            subtitle = "Specify the size of the embedded video in bytes",
-            tooltip_text = "If the video size cannot be detected automatically,\n"
+            title = _("Manual Video Size"),
+            subtitle = _("Specify the size of the embedded video in bytes"),
+            tooltip_text = _("If the video size cannot be detected automatically,\n"
                             + "you can manually specify its size in bytes.\n"
-                            + "Leave at 0 to use automatic detection.",
+                            + "Leave at 0 to use automatic detection."),
             expanded = false,
             show_enable_switch = false,
         };
@@ -696,8 +696,8 @@ public class LivePhotoConv.Application : Adw.Application {
             halign = Gtk.Align.END,
             valign = Gtk.Align.CENTER,
             width_chars = 12,
-            tooltip_text = "Enter the exact size of the video portion in bytes.\n"
-                            + "Only needed if automatic detection fails.",
+            tooltip_text = _("Enter the exact size of the video portion in bytes.\n"
+                            + "Only needed if automatic detection fails."),
         };
 
         var spin_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6) {
@@ -706,7 +706,7 @@ public class LivePhotoConv.Application : Adw.Application {
             margin_top = 6,
             margin_bottom = 6,
         };
-        spin_box.append (new Gtk.Label ("Video size in bytes") {
+        spin_box.append (new Gtk.Label (_("Video size in bytes")) {
             hexpand = true,
             xalign = 0,
             valign = Gtk.Align.CENTER,
@@ -723,22 +723,22 @@ public class LivePhotoConv.Application : Adw.Application {
     private void on_repair_clicked () {
         var files = repair_live_photo_area.files;
         if (files.length == 0) {
-            show_toast ("Please select a live photo file first");
+            show_toast (_("Please select a live photo file first"));
             return;
         }
 
         bool force = repair_force_check.active;
         uint video_size = (uint) repair_video_size_spin.value;
 
-        start_work (repair_button, "Repairing…");
+        start_work (repair_button, _("Repairing…"));
         repair_batch_async.begin (files, force, video_size, repair_button, (obj, res) => {
             try {
                 repair_batch_async.end (res);
-                end_work (repair_button, "Repair", repair_live_photo_area.files.length > 0);
-                show_toast (@"$(files.length) file(s) repaired");
+                end_work (repair_button, _("Repair"), repair_live_photo_area.files.length > 0);
+                show_toast (ngettext ("%u file repaired", "%u files repaired", (uint) files.length).printf ((uint) files.length));
             } catch (Error e) {
-                end_work (repair_button, "Repair", repair_live_photo_area.files.length > 0);
-                show_toast (@"Error: $(e.message)");
+                end_work (repair_button, _("Repair"), repair_live_photo_area.files.length > 0);
+                show_toast (_("Error: %s").printf (e.message));
             }
         });
     }
@@ -760,7 +760,7 @@ public class LivePhotoConv.Application : Adw.Application {
         int total = (int) files.length;
         int processed = 0;
 
-        report_progress (button, "Extracting", 0, total);
+        report_progress (button, _("Extracting"), 0, total);
 
         new Thread<void> ("extract-batch", () => {
             foreach (unowned var file in files) {
@@ -787,7 +787,7 @@ public class LivePhotoConv.Application : Adw.Application {
                 }
                 processed += 1;
                 Idle.add (() => {
-                    report_progress (button, "Extracting", processed, total);
+                    report_progress (button, _("Extracting"), processed, total);
                     return false;
                 });
             }
@@ -806,7 +806,7 @@ public class LivePhotoConv.Application : Adw.Application {
         int total = (int) files.length;
         int processed = 0;
 
-        report_progress (button, "Repairing", 0, total);
+        report_progress (button, _("Repairing"), 0, total);
 
         new Thread<void> ("repair-batch", () => {
             foreach (unowned var file in files) {
@@ -824,7 +824,7 @@ public class LivePhotoConv.Application : Adw.Application {
                 }
                 processed += 1;
                 Idle.add (() => {
-                    report_progress (button, "Repairing", processed, total);
+                    report_progress (button, _("Repairing"), processed, total);
                     return false;
                 });
             }
@@ -842,6 +842,10 @@ public class LivePhotoConv.Application : Adw.Application {
      * @return exit code
      */
     public static int main (string[] args) {
+        Intl.setlocale (LocaleCategory.ALL, "");
+        Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        Intl.textdomain (GETTEXT_PACKAGE);
         var app = new Application ();
         return app.run (args);
     }

--- a/src/main.vala
+++ b/src/main.vala
@@ -124,7 +124,10 @@ class LivePhotoConv.Main {
     };
 
     static int main (string[] original_args) {
-        Intl.setlocale ();
+        Intl.setlocale (LocaleCategory.ALL, "");
+        Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        Intl.textdomain (GETTEXT_PACKAGE);
 
 #if WINDOWS
         var args = Win32.get_command_line ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,25 @@
-version_file = vcs_tag(
-   command: meson.project_version(),
-     input: 'version.vala.in',
-    output: 'version.vala',
+vcs_version = meson.project_version()
+git = find_program('git', required: false)
+if git.found()
+  git_desc = run_command('git', 'describe', '--tags', '--abbrev=12', '--dirty', check: false)
+  if git_desc.returncode() == 0
+    raw = git_desc.stdout().strip()
+    if raw.startswith('v')
+      raw = raw.substring(1)
+    endif
+    vcs_version = raw.replace('-', '.')
+  endif
+endif
+
+localedir = join_paths(get_option('prefix'), get_option('localedir'))
+constants_data = configuration_data()
+constants_data.set_quoted('VERSION', vcs_version)
+constants_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+constants_data.set_quoted('LOCALEDIR', localedir)
+constants_file = configure_file(
+    input: 'constants.vala.in',
+    output: 'constants.vala',
+    configuration: constants_data,
 )
 
 lib_common_sources = [
@@ -24,7 +42,7 @@ if with_gst
   ]
 endif
 
-lib_sources = lib_common_sources + [version_file]
+lib_sources = lib_common_sources + [constants_file]
 
 lib_gi_name = 'LivePhotoTools'
 lib_gi_version = lib_api_version  # Use centralized API version
@@ -247,7 +265,7 @@ if valadoc.found()
         '--vapidir', join_paths(meson.global_source_root(), 'vapi'),
         '--doclet=devhelp',
         '-o', 'docs',
-        version_file.full_path(),
+        constants_file.full_path(),
         '--gir', '@OUTPUT@',
         '@INPUT@'
     ],


### PR DESCRIPTION
- Integrate Meson `i18n` module and configure `gettext` for the project.
- Add `po/` directory with `LINGUAS`, `POTFILES`, and template `.pot` file.
- Include initial translations for de, es, fr, ja, ko, pt_BR, ru, and zh_CN.