### PR TITLE
feat: add Android APK build support via pixiewood and custom dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,13 +162,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y \
           build-essential ccache cmake curl gettext git git-lfs \
-          glslc gobject-introspection gir1.2-glib-2.0-dev libglib2.0-dev-bin valac \
+          glslc gobject-introspection gir1.2-glib-2.0-dev gir1.2-appstream-1.0 libglib2.0-dev-bin valac \
           libglib-perl libglib-object-introspection-perl \
           libipc-run-perl libjson-perl libset-scalar-perl \
           libxml-libxml-perl libxml-libxslt-perl \
           libxml2-utils ninja-build openjdk-17-jdk \
           perl pkg-config python3 python3-pip sassc unzip wget xz-utils \
-          libexiv2-dev
+          libgexiv2-dev
         pip3 install --break-system-packages meson
 
     - name: Setup ccache
@@ -177,26 +177,33 @@ jobs:
         key: android-${{ env.MESON_ARCH }}
         max-size: 2G
 
-    # ── Generate gexiv2 VAPI (host build, needed for cross-compilation) ──
+    # ── Detect host gexiv2 version and reuse system VAPI ──
 
-    - name: Generate gexiv2 VAPI for host
+    - name: Detect host gexiv2 version and setup VAPI
       run: |
+        # Query the gexiv2 version installed on the host (Ubuntu)
+        GEXIV2_VERSION=$(pkg-config --modversion gexiv2)
+        echo "Host gexiv2 version: ${GEXIV2_VERSION}"
+        echo "gexiv2_version=${GEXIV2_VERSION}" >> "${GITHUB_ENV}"
+
+        # Copy the system VAPI so Vala can use it during cross-compilation
         mkdir -p vapi
-        wget -q "https://download.gnome.org/sources/gexiv2/0.16/gexiv2-0.16.0.tar.xz"
-        tar -xf gexiv2-0.16.0.tar.xz
-        meson setup build-gexiv2-native gexiv2-0.16.0 \
-          -Dintrospection=true \
-          -Dvapi=true \
-          -Dtests=false \
-          -Dtools=false \
-          -Dpython3=false \
-          -Dgtk_doc=false
-        meson compile -C build-gexiv2-native
-        find build-gexiv2-native -name "gexiv2*.vapi" -exec cp {} vapi/ \;
-        find build-gexiv2-native -name "gexiv2*.deps" -exec cp {} vapi/ \;
-        rm -rf gexiv2-0.16.0 build-gexiv2-native gexiv2-0.16.0.tar.xz
-        echo "Generated VAPI files:"
-        ls -la vapi/
+        cp /usr/share/vala/vapi/gexiv2.vapi vapi/ 2>/dev/null || true
+        cp /usr/share/vala/vapi/gexiv2.deps vapi/ 2>/dev/null || true
+
+        # Generate a matching wrap file for the Android cross-build
+        GEXIV2_MM=$(echo "${GEXIV2_VERSION}" | cut -d. -f1,2)
+        printf '%s\n' \
+          '[wrap-file]' \
+          "directory = gexiv2-${GEXIV2_VERSION}" \
+          "source_url = https://download.gnome.org/sources/gexiv2/${GEXIV2_MM}/gexiv2-${GEXIV2_VERSION}.tar.xz" \
+          "source_filename = gexiv2-${GEXIV2_VERSION}.tar.xz" \
+          '' \
+          '[provide]' \
+          'dependency_names = gexiv2' \
+          > subprojects/gexiv2.wrap
+        echo "Generated gexiv2.wrap:"
+        cat subprojects/gexiv2.wrap
 
     # ── Android SDK / NDK ──
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,10 +134,224 @@ jobs:
         brew install --HEAD wszqkzqk/live-photo-conv/live-photo-conv
         brew test wszqkzqk/live-photo-conv/live-photo-conv
 
+  build-android:
+    name: Build Android APK (aarch64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+
+    env:
+      ANDROID_SDKVER: "35.0.0"
+      ANDROID_NDKVER: "27.2.12479018"
+      ANDROID_API: 35
+      ABI: arm64-v8a
+      MESON_ARCH: aarch64
+      GST_VERSION: "1.28.2"
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up environment paths
+      run: |
+        echo "ANDROID_HOME=${HOME}/android-sdk" >> "${GITHUB_ENV}"
+        echo "DEPS_PREFIX=${HOME}/android-deps" >> "${GITHUB_ENV}"
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential ccache cmake curl gettext git git-lfs \
+          glslc gobject-introspection gir1.2-glib-2.0-dev libglib2.0-dev-bin valac \
+          libglib-perl libglib-object-introspection-perl \
+          libipc-run-perl libjson-perl libset-scalar-perl \
+          libxml-libxml-perl libxml-libxslt-perl \
+          libxml2-utils ninja-build openjdk-17-jdk \
+          perl pkg-config python3 python3-pip sassc unzip wget xz-utils
+        pip3 install --break-system-packages meson
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: android-${{ env.MESON_ARCH }}
+        max-size: 2G
+
+    # ── Android SDK / NDK ──
+
+    - name: Restore Android SDK cache
+      id: cache-sdk
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.ANDROID_HOME }}
+        key: android-sdk-${{ env.ANDROID_SDKVER }}-${{ env.ANDROID_NDKVER }}-v2
+
+    - name: Install Android SDK
+      if: steps.cache-sdk.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p "${ANDROID_HOME}"
+        wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
+        unzip -q commandlinetools-linux-*.zip
+        mkdir -p "${ANDROID_HOME}/cmdline-tools/latest"
+        mv cmdline-tools/* "${ANDROID_HOME}/cmdline-tools/latest/"
+        rm -rf cmdline-tools commandlinetools-linux-*.zip
+
+        # Accept SDK licenses (sha1 hash method, reliable for CI)
+        mkdir -p "${ANDROID_HOME}/licenses"
+        for entry in \
+          "android-sdk-license=8933bad161af4178b1185d1a37fbf41ea5269c55" \
+          "android-sdk-license=d56f5187479451eabf01fb78af6dfcb131a6481e" \
+          "android-sdk-license=24333f8a63b6825ea9c5514f83c2829b004d1fee" \
+          "android-sdk-preview-license=84831b9409646a918e30573bab4c9c91346d8abd" \
+          "android-sdk-preview-license-old=79120722343a6f314e0719f863036c702b0e6b2a"; do
+          name="${entry%%=*}"
+          hash="${entry#*=}"
+          echo "$hash" >> "${ANDROID_HOME}/licenses/${name}"
+        done
+
+        # Suppress SDK repository prompt
+        mkdir -p ~/.android
+        echo 'count=0' > ~/.android/repositories.cfg
+
+        # Install SDK components
+        "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --sdk_root="${ANDROID_HOME}" \
+          "build-tools;${ANDROID_SDKVER}" \
+          "ndk;${ANDROID_NDKVER}" \
+          "platforms;android-${ANDROID_API}"
+
+    - name: Save Android SDK cache
+      if: steps.cache-sdk.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.ANDROID_HOME }}
+        key: ${{ steps.cache-sdk.outputs.cache-primary-key }}
+
+    # ── GStreamer & Exiv2/GExiv2 deps ──
+
+    - name: Restore pre-built deps cache
+      id: cache-deps
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.DEPS_PREFIX }}
+        key: android-deps-${{ env.GST_VERSION }}-exiv2-v4
+
+    - name: Download and extract pre-built GStreamer
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+        set -euo pipefail
+        GST_TARBALL="gstreamer-1.0-android-universal-${GST_VERSION}.tar.xz"
+        GST_URL="https://gstreamer.freedesktop.org/pkg/android/${GST_VERSION}/${GST_TARBALL}"
+        TMPDIR="${RUNNER_TEMP}/gst-extract"
+        mkdir -p "${DEPS_PREFIX}" "${TMPDIR}"
+
+        echo "Downloading GStreamer ${GST_VERSION}..."
+        wget -nv "${GST_URL}" -O "${RUNNER_TEMP}/${GST_TARBALL}"
+
+        echo "Extracting to ${TMPDIR}..."
+        tar -xf "${RUNNER_TEMP}/${GST_TARBALL}" -C "${TMPDIR}"
+
+        # The tarball has a flat structure: arm64/ armv7/ x86/ x86_64/ share/
+        cp -a "${TMPDIR}/arm64/"* "${DEPS_PREFIX}/"
+        if [ -d "${TMPDIR}/share" ]; then
+          mkdir -p "${DEPS_PREFIX}/share"
+          cp -a "${TMPDIR}/share/"* "${DEPS_PREFIX}/share/"
+        fi
+
+        # Keep GStreamer's GLib shared libs (.so) for linking against by GExiv2,
+        # but remove static libs (.a) which carry unresolved pcre2 references,
+        # and remove bundled Expat/zlib pkg-config (we build our own).
+        rm -f "${DEPS_PREFIX}/lib/pkgconfig"/{expat,pcre2-8}.pc 2>/dev/null || true
+        find "${DEPS_PREFIX}" -name '*.a' -delete
+
+        rm -rf "${RUNNER_TEMP}/${GST_TARBALL}" "${TMPDIR}"
+        echo "${GST_VERSION}" > "${DEPS_PREFIX}/.gstreamer-version"
+        echo "GStreamer ${GST_VERSION} installed to ${DEPS_PREFIX}"
+
+    - name: Build Expat, Exiv2 and GExiv2 for Android
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+        bash android/build-exiv2-android.sh \
+          "${ANDROID_HOME}/ndk/${ANDROID_NDKVER}" \
+          "${ANDROID_API}" \
+          "${ABI}" \
+          "${DEPS_PREFIX}"
+
+    - name: Save pre-built deps cache
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.DEPS_PREFIX }}
+        key: ${{ steps.cache-deps.outputs.cache-primary-key }}
+
+    # ── pixiewood build ──
+
+    - name: Clone pixiewood and mini-studio
+      run: |
+        git clone https://github.com/sp1ritCS/gtk-android-builder.git --branch android36 pixiewood
+        git clone --depth 1 https://github.com/sp1ritCS/mini-studio.git
+
+    - name: pixiewood prepare
+      run: |
+        # Tell pkg-config about our extra pre-built deps (GStreamer, Exiv2, etc.)
+        # PKG_CONFIG_PATH supplements the default search paths that pixiewood sets up.
+        export PKG_CONFIG_PATH="${DEPS_PREFIX}/lib/pkgconfig:${DEPS_PREFIX}/share/pkgconfig"
+        export PKG_CONFIG_SYSROOT_DIR="${DEPS_PREFIX}"
+
+        ./pixiewood/pixiewood prepare --release \
+          -s "${ANDROID_HOME}" \
+          -a ./mini-studio \
+          pixiewood.xml
+
+    - name: pixiewood generate
+      run: |
+        export PKG_CONFIG_PATH="${DEPS_PREFIX}/lib/pkgconfig:${DEPS_PREFIX}/share/pkgconfig"
+        ./pixiewood/pixiewood generate
+
+    - name: Copy extra native libraries for APK packaging
+      run: |
+        # pixiewood packages .so files from its meson install prefix,
+        # but our pre-built deps (GStreamer, Exiv2, Expat) are external.
+        # Copy them into the generated Gradle project's jniLibs.
+        JNILIBS=".pixiewood/android/app/src/main/jniLibs/${ABI}"
+        mkdir -p "${JNILIBS}"
+
+        # Copy main shared libraries
+        cp "${DEPS_PREFIX}"/lib/*.so "${JNILIBS}/" 2>/dev/null || true
+
+        # Copy GStreamer plugins into the expected subdirectory
+        if [ -d "${DEPS_PREFIX}/lib/gstreamer-1.0" ]; then
+          mkdir -p "${JNILIBS}/gstreamer-1.0"
+          cp "${DEPS_PREFIX}/lib/gstreamer-1.0/"*.so "${JNILIBS}/gstreamer-1.0/" 2>/dev/null || true
+        fi
+
+        echo "Extra native libraries staged:"
+        find "${JNILIBS}" -name "*.so" | sort
+
+    - name: pixiewood build
+      run: |
+        export PKG_CONFIG_PATH="${DEPS_PREFIX}/lib/pkgconfig:${DEPS_PREFIX}/share/pkgconfig"
+        ./pixiewood/pixiewood build
+
+    - name: Collect APK
+      run: |
+        mkdir -p apks
+        cp .pixiewood/android/app/build/outputs/apk/release/*.apk apks/ 2>/dev/null || \
+        cp .pixiewood/android/app/build/outputs/apk/debug/*.apk apks/ 2>/dev/null || true
+        echo "APKs produced:"
+        ls -lh apks/
+
+    - name: Upload APK artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: android-apk-aarch64
+        path: apks/*.apk
+
+
   release:
     name: Release
     if: github.ref_type == 'tag'
-    needs: [build-archlinux, build-flatpak, build-windows, build-macos]
+    needs: [build-archlinux, build-flatpak, build-windows, build-macos, build-android]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -152,6 +366,11 @@ jobs:
       with:
         name: flatpak-bundle
         merge-multiple: true
+        path: dist
+
+    - uses: actions/download-artifact@v8
+      with:
+        name: android-apk-aarch64
         path: dist
 
     - name: Remove Debug Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
   build-android:
     name: Build Android APK (aarch64)
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     strategy:
       fail-fast: false
 
@@ -147,7 +147,6 @@ jobs:
       ANDROID_API: 35
       ABI: arm64-v8a
       MESON_ARCH: aarch64
-      GST_VERSION: "1.28.2"
 
     steps:
     - uses: actions/checkout@v6
@@ -157,7 +156,6 @@ jobs:
     - name: Set up environment paths
       run: |
         echo "ANDROID_HOME=${HOME}/android-sdk" >> "${GITHUB_ENV}"
-        echo "DEPS_PREFIX=${HOME}/android-deps" >> "${GITHUB_ENV}"
 
     - name: Install system dependencies
       run: |
@@ -169,7 +167,8 @@ jobs:
           libipc-run-perl libjson-perl libset-scalar-perl \
           libxml-libxml-perl libxml-libxslt-perl \
           libxml2-utils ninja-build openjdk-17-jdk \
-          perl pkg-config python3 python3-pip sassc unzip wget xz-utils
+          perl pkg-config python3 python3-pip sassc unzip wget xz-utils \
+          libexiv2-dev
         pip3 install --break-system-packages meson
 
     - name: Setup ccache
@@ -177,6 +176,27 @@ jobs:
       with:
         key: android-${{ env.MESON_ARCH }}
         max-size: 2G
+
+    # ── Generate gexiv2 VAPI (host build, needed for cross-compilation) ──
+
+    - name: Generate gexiv2 VAPI for host
+      run: |
+        mkdir -p vapi
+        wget -q "https://download.gnome.org/sources/gexiv2/0.16/gexiv2-0.16.0.tar.xz"
+        tar -xf gexiv2-0.16.0.tar.xz
+        meson setup build-gexiv2-native gexiv2-0.16.0 \
+          -Dintrospection=true \
+          -Dvapi=true \
+          -Dtests=false \
+          -Dtools=false \
+          -Dpython3=false \
+          -Dgtk_doc=false
+        meson compile -C build-gexiv2-native
+        find build-gexiv2-native -name "gexiv2*.vapi" -exec cp {} vapi/ \;
+        find build-gexiv2-native -name "gexiv2*.deps" -exec cp {} vapi/ \;
+        rm -rf gexiv2-0.16.0 build-gexiv2-native gexiv2-0.16.0.tar.xz
+        echo "Generated VAPI files:"
+        ls -la vapi/
 
     # ── Android SDK / NDK ──
 
@@ -227,110 +247,100 @@ jobs:
         path: ${{ env.ANDROID_HOME }}
         key: ${{ steps.cache-sdk.outputs.cache-primary-key }}
 
-    # ── GStreamer & Exiv2/GExiv2 deps ──
+    # ── Cache subprojects source downloads ──
 
-    - name: Restore pre-built deps cache
-      id: cache-deps
+    - name: Restore subprojects cache
+      id: cache-subprojects
       uses: actions/cache/restore@v4
       with:
-        path: ${{ env.DEPS_PREFIX }}
-        key: android-deps-${{ env.GST_VERSION }}-exiv2-v4
+        path: subprojects/
+        key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-${{ env.ANDROID_NDKVER }}
 
-    - name: Download and extract pre-built GStreamer
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        set -euo pipefail
-        GST_TARBALL="gstreamer-1.0-android-universal-${GST_VERSION}.tar.xz"
-        GST_URL="https://gstreamer.freedesktop.org/pkg/android/${GST_VERSION}/${GST_TARBALL}"
-        TMPDIR="${RUNNER_TEMP}/gst-extract"
-        mkdir -p "${DEPS_PREFIX}" "${TMPDIR}"
-
-        echo "Downloading GStreamer ${GST_VERSION}..."
-        wget -nv "${GST_URL}" -O "${RUNNER_TEMP}/${GST_TARBALL}"
-
-        echo "Extracting to ${TMPDIR}..."
-        tar -xf "${RUNNER_TEMP}/${GST_TARBALL}" -C "${TMPDIR}"
-
-        # The tarball has a flat structure: arm64/ armv7/ x86/ x86_64/ share/
-        cp -a "${TMPDIR}/arm64/"* "${DEPS_PREFIX}/"
-        if [ -d "${TMPDIR}/share" ]; then
-          mkdir -p "${DEPS_PREFIX}/share"
-          cp -a "${TMPDIR}/share/"* "${DEPS_PREFIX}/share/"
-        fi
-
-        # Keep GStreamer's GLib shared libs (.so) for linking against by GExiv2,
-        # but remove static libs (.a) which carry unresolved pcre2 references,
-        # and remove bundled Expat/zlib pkg-config (we build our own).
-        rm -f "${DEPS_PREFIX}/lib/pkgconfig"/{expat,pcre2-8}.pc 2>/dev/null || true
-        find "${DEPS_PREFIX}" -name '*.a' -delete
-
-        rm -rf "${RUNNER_TEMP}/${GST_TARBALL}" "${TMPDIR}"
-        echo "${GST_VERSION}" > "${DEPS_PREFIX}/.gstreamer-version"
-        echo "GStreamer ${GST_VERSION} installed to ${DEPS_PREFIX}"
-
-    - name: Build Expat, Exiv2 and GExiv2 for Android
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        bash android/build-exiv2-android.sh \
-          "${ANDROID_HOME}/ndk/${ANDROID_NDKVER}" \
-          "${ANDROID_API}" \
-          "${ABI}" \
-          "${DEPS_PREFIX}"
-
-    - name: Save pre-built deps cache
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ env.DEPS_PREFIX }}
-        key: ${{ steps.cache-deps.outputs.cache-primary-key }}
-
-    # ── pixiewood build ──
+    # ── pixiewood unified build (all deps from source, single GLib) ──
 
     - name: Clone pixiewood and mini-studio
       run: |
         git clone https://github.com/sp1ritCS/gtk-android-builder.git --branch android36 pixiewood
         git clone --depth 1 https://github.com/sp1ritCS/mini-studio.git
 
-    - name: pixiewood prepare
+    - name: pixiewood prepare (first pass — download subprojects)
       run: |
-        # Tell pkg-config about our extra pre-built deps (GStreamer, Exiv2, etc.)
-        # PKG_CONFIG_PATH supplements the default search paths that pixiewood sets up.
-        export PKG_CONFIG_PATH="${DEPS_PREFIX}/lib/pkgconfig:${DEPS_PREFIX}/share/pkgconfig"
-        export PKG_CONFIG_SYSROOT_DIR="${DEPS_PREFIX}"
-
         ./pixiewood/pixiewood prepare --release \
           -s "${ANDROID_HOME}" \
           -a ./mini-studio \
           pixiewood.xml
 
-    - name: pixiewood generate
+    - name: Save subprojects cache
+      if: steps.cache-subprojects.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: subprojects/
+        key: ${{ steps.cache-subprojects.outputs.cache-primary-key }}
+
+    # GStreamer monorepo root does not expose gst_dep / override standard
+    # dependency names. We patch it so that meson can find gstreamer-1.0 etc.
+    - name: Patch GStreamer subproject for dependency forwarding
       run: |
-        export PKG_CONFIG_PATH="${DEPS_PREFIX}/lib/pkgconfig:${DEPS_PREFIX}/share/pkgconfig"
-        ./pixiewood/pixiewood generate
-
-    - name: Copy extra native libraries for APK packaging
-      run: |
-        # pixiewood packages .so files from its meson install prefix,
-        # but our pre-built deps (GStreamer, Exiv2, Expat) are external.
-        # Copy them into the generated Gradle project's jniLibs.
-        JNILIBS=".pixiewood/android/app/src/main/jniLibs/${ABI}"
-        mkdir -p "${JNILIBS}"
-
-        # Copy main shared libraries
-        cp "${DEPS_PREFIX}"/lib/*.so "${JNILIBS}/" 2>/dev/null || true
-
-        # Copy GStreamer plugins into the expected subdirectory
-        if [ -d "${DEPS_PREFIX}/lib/gstreamer-1.0" ]; then
-          mkdir -p "${JNILIBS}/gstreamer-1.0"
-          cp "${DEPS_PREFIX}/lib/gstreamer-1.0/"*.so "${JNILIBS}/gstreamer-1.0/" 2>/dev/null || true
+        GST_DIR="subprojects/gstreamer"
+        if [ -f "${GST_DIR}/meson.build" ]; then
+          {
+            echo ""
+            echo "# === Injected by live-photo-conv CI ==="
+            echo "# Forward subproject dependencies for external consumers."
+            echo "# GStreamer monorepo root normally does not expose these."
+            echo "_gst_core_sp = subproject('gstreamer')"
+            echo "gst_dep      = _gst_core_sp.get_variable('gst_dep')"
+            echo "gst_base_dep = _gst_core_sp.get_variable('gst_base_dep')"
+            echo "meson.override_dependency('gstreamer-1.0',      gst_dep)"
+            echo "meson.override_dependency('gstreamer-base-1.0', gst_base_dep)"
+            echo ""
+            echo "_gst_base_sp = subproject('gst-plugins-base')"
+            echo "app_dep      = _gst_base_sp.get_variable('app_dep')"
+            echo "video_dep    = _gst_base_sp.get_variable('video_dep')"
+            echo "pbutils_dep  = _gst_base_sp.get_variable('pbutils_dep')"
+            echo "meson.override_dependency('gstreamer-app-1.0',    app_dep)"
+            echo "meson.override_dependency('gstreamer-video-1.0',  video_dep)"
+            echo "meson.override_dependency('gstreamer-pbutils-1.0', pbutils_dep)"
+            echo "# === End injection ==="
+          } >> "${GST_DIR}/meson.build"
+          echo "Patched ${GST_DIR}/meson.build"
+        else
+          echo "WARNING: GStreamer subproject not found, skipping patch"
         fi
 
-        echo "Extra native libraries staged:"
-        find "${JNILIBS}" -name "*.so" | sort
+    - name: Reconfigure meson with patched GStreamer
+      run: |
+        # Re-run meson setup so that it re-parses the patched GStreamer
+        # subproject and finds gstreamer-1.0 / gstreamer-app-1.0.
+        meson setup --reconfigure .pixiewood/bin-aarch64 . \
+          --cross-file .pixiewood/toolchain.cross \
+          --cross-file pixiewood/prepare/arch/aarch64.cross \
+          --cross-file pixiewood/prepare/android.cross \
+          --buildtype release \
+          --strip \
+          -Dgui=enabled \
+          -Dgst=enabled \
+          -Dgir=disabled \
+          -Dmanpages=disabled \
+          -Ddocs=disabled \
+          --force-fallback-for=gstreamer \
+          -Dgstreamer:base=enabled \
+          -Dgstreamer:good=disabled \
+          -Dgstreamer:bad=disabled \
+          -Dgstreamer:ugly=disabled \
+          -Dgstreamer:libav=disabled \
+          -Dgstreamer:tests=disabled \
+          -Dgstreamer:examples=disabled \
+          -Dgstreamer:introspection=disabled \
+          -Dgstreamer:doc=disabled \
+          -Dgstreamer:tools=disabled
+
+    - name: pixiewood generate
+      run: |
+        ./pixiewood/pixiewood generate
 
     - name: pixiewood build
       run: |
-        export PKG_CONFIG_PATH="${DEPS_PREFIX}/lib/pkgconfig:${DEPS_PREFIX}/share/pkgconfig"
         ./pixiewood/pixiewood build
 
     - name: Collect APK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
         git clone https://github.com/sp1ritCS/gtk-android-builder.git --branch android36 pixiewood
         git clone --depth 1 https://github.com/sp1ritCS/mini-studio.git
 
-    - name: pixiewood prepare (first pass — download subprojects)
+    - name: pixiewood prepare
       run: |
         ./pixiewood/pixiewood prepare --release \
           -s "${ANDROID_HOME}" \
@@ -283,64 +283,6 @@ jobs:
       with:
         path: subprojects/
         key: ${{ steps.cache-subprojects.outputs.cache-primary-key }}
-
-    # GStreamer monorepo root does not expose gst_dep / override standard
-    # dependency names. We patch it so that meson can find gstreamer-1.0 etc.
-    - name: Patch GStreamer subproject for dependency forwarding
-      run: |
-        GST_DIR="subprojects/gstreamer"
-        if [ -f "${GST_DIR}/meson.build" ]; then
-          {
-            echo ""
-            echo "# === Injected by live-photo-conv CI ==="
-            echo "# Forward subproject dependencies for external consumers."
-            echo "# GStreamer monorepo root normally does not expose these."
-            echo "_gst_core_sp = subproject('gstreamer')"
-            echo "gst_dep      = _gst_core_sp.get_variable('gst_dep')"
-            echo "gst_base_dep = _gst_core_sp.get_variable('gst_base_dep')"
-            echo "meson.override_dependency('gstreamer-1.0',      gst_dep)"
-            echo "meson.override_dependency('gstreamer-base-1.0', gst_base_dep)"
-            echo ""
-            echo "_gst_base_sp = subproject('gst-plugins-base')"
-            echo "app_dep      = _gst_base_sp.get_variable('app_dep')"
-            echo "video_dep    = _gst_base_sp.get_variable('video_dep')"
-            echo "pbutils_dep  = _gst_base_sp.get_variable('pbutils_dep')"
-            echo "meson.override_dependency('gstreamer-app-1.0',    app_dep)"
-            echo "meson.override_dependency('gstreamer-video-1.0',  video_dep)"
-            echo "meson.override_dependency('gstreamer-pbutils-1.0', pbutils_dep)"
-            echo "# === End injection ==="
-          } >> "${GST_DIR}/meson.build"
-          echo "Patched ${GST_DIR}/meson.build"
-        else
-          echo "WARNING: GStreamer subproject not found, skipping patch"
-        fi
-
-    - name: Reconfigure meson with patched GStreamer
-      run: |
-        # Re-run meson setup so that it re-parses the patched GStreamer
-        # subproject and finds gstreamer-1.0 / gstreamer-app-1.0.
-        meson setup --reconfigure .pixiewood/bin-aarch64 . \
-          --cross-file .pixiewood/toolchain.cross \
-          --cross-file pixiewood/prepare/arch/aarch64.cross \
-          --cross-file pixiewood/prepare/android.cross \
-          --buildtype release \
-          --strip \
-          -Dgui=enabled \
-          -Dgst=enabled \
-          -Dgir=disabled \
-          -Dmanpages=disabled \
-          -Ddocs=disabled \
-          --force-fallback-for=gstreamer \
-          -Dgstreamer:base=enabled \
-          -Dgstreamer:good=disabled \
-          -Dgstreamer:bad=disabled \
-          -Dgstreamer:ugly=disabled \
-          -Dgstreamer:libav=disabled \
-          -Dgstreamer:tests=disabled \
-          -Dgstreamer:examples=disabled \
-          -Dgstreamer:introspection=disabled \
-          -Dgstreamer:doc=disabled \
-          -Dgstreamer:tools=disabled
 
     - name: pixiewood generate
       run: |

--- a/android/app-icon-foreground.svg
+++ b/android/app-icon-foreground.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 108 108">
+  <!-- Adaptive icon foreground for Live Photo Converter -->
+  <!-- A simple camera/live-photo icon: play triangle inside a photo frame -->
+  <defs>
+    <clipPath id="circle">
+      <path d="M54 8C28.6 8 8 28.6 8 54s20.6 46 46 46 46-20.6 46-46S79.4 8 54 8zm0 84c-21 0-38-17-38-38s17-38 38-38 38 17 38 38-17 38-38 38z"/>
+    </clipPath>
+  </defs>
+
+  <!-- Photo frame -->
+  <g clip-path="url(#circle)">
+    <!-- Top bar: camera flash -->
+    <rect x="14" y="24" width="24" height="4" rx="2" fill="white" opacity="0.9"/>
+    <!-- Photo area -->
+    <rect x="14" y="32" width="80" height="52" rx="4" fill="white" opacity="0.9"/>
+    <!-- Play triangle -->
+    <polygon points="48,48 48,68 66,58" fill="white"/>
+  </g>
+
+  <!-- Circle border -->
+  <path d="M54 8C28.6 8 8 28.6 8 54s20.6 46 46 46 46-20.6 46-46S79.4 8 54 8zm0 84c-21 0-38-17-38-38s17-38 38-38 38 17 38 38-17 38-38 38z"
+        fill="none" stroke="white" stroke-width="4" opacity="0.7"/>
+</svg>

--- a/android/build-exiv2-android.sh
+++ b/android/build-exiv2-android.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# Cross-compile Expat, Exiv2, and GExiv2 for Android
+# Usage: ./build-exiv2-android.sh <ndk_path> <api_level> <abi> <prefix>
+#
+# Example: ./build-exiv2-android.sh /opt/android/ndk/27.2.12479018 35 arm64-v8a /opt/android-deps
+
+set -euo pipefail
+
+NDK="${1:?Usage: $0 <ndk_path> <api_level> <abi> <prefix>}"
+API="${2:?}"
+ABI="${3:?}"
+PREFIX="${4:?}"
+
+TOOLCHAIN="${NDK}/build/cmake/android.toolchain.cmake"
+export PATH="${NDK}/toolchains/llvm/prebuilt/linux-x86_64/bin:${PATH}"
+
+# Version pins
+EXPAT_VERSION="2.7.5"
+EXIV2_VERSION="0.28.8"
+GEXIV2_VERSION="0.16.0"
+
+WORK="/tmp/build-android-deps"
+mkdir -p "${WORK}" "${PREFIX}"
+
+echo "=== Building Expat ${EXPAT_VERSION} (Android) ==="
+echo "  Downloading..."
+wget -nv "https://github.com/libexpat/libexpat/releases/download/R_$(echo ${EXPAT_VERSION} | tr . _)/expat-${EXPAT_VERSION}.tar.xz" -O "${WORK}/expat.tar.xz"
+echo "  Extracting..."
+    tar -xf "${WORK}/expat.tar.xz" -C "${WORK}/"
+
+    cmake -S "${WORK}/expat-${EXPAT_VERSION}" -B "${WORK}/build-expat" -G Ninja \
+        -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
+        -DANDROID_ABI="${ABI}" \
+        -DANDROID_PLATFORM="android-${API}" \
+        -DANDROID_STL="c++_shared" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+        -DEXPAT_BUILD_TOOLS=OFF \
+        -DEXPAT_BUILD_EXAMPLES=OFF \
+        -DEXPAT_BUILD_TESTS=OFF \
+        -DEXPAT_BUILD_DOCS=OFF \
+        -DEXPAT_SHARED_LIBS=ON
+    cmake --build "${WORK}/build-expat" --parallel "$(nproc)"
+    cmake --install "${WORK}/build-expat"
+    rm -rf "${WORK}/expat-${EXPAT_VERSION}" "${WORK}/build-expat" "${WORK}/expat.tar.xz"
+    echo "Expat ${EXPAT_VERSION} installed (Android)."
+
+echo "=== Building Exiv2 ${EXIV2_VERSION} (Android) ==="
+echo "  Downloading..."
+wget -nv "https://github.com/Exiv2/exiv2/archive/refs/tags/v${EXIV2_VERSION}.tar.gz" -O "${WORK}/exiv2.tar.gz"
+echo "  Extracting..."
+tar -xf "${WORK}/exiv2.tar.gz" -C "${WORK}/"
+
+    cmake -S "${WORK}/exiv2-${EXIV2_VERSION}" -B "${WORK}/build-exiv2" -G Ninja \
+        -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
+        -DANDROID_ABI="${ABI}" \
+        -DANDROID_PLATFORM="android-${API}" \
+        -DANDROID_STL="c++_shared" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+        -DCMAKE_PREFIX_PATH="${PREFIX}" \
+        -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH \
+        -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+        -DCMAKE_CXX_FLAGS="-Dlibiconv_open=iconv_open -Dlibiconv=iconv -Dlibiconv_close=iconv_close" \
+        -DBUILD_SHARED_LIBS=ON \
+        -DEXIV2_ENABLE_XMP=ON \
+        -DEXIV2_ENABLE_PNG=ON \
+        -DEXIV2_ENABLE_NLS=OFF \
+        -DEXIV2_ENABLE_BROTLI=OFF \
+        -DEXIV2_ENABLE_INIH=OFF \
+        -DEXIV2_ENABLE_WEBREADY=OFF \
+        -DEXIV2_ENABLE_CURL=OFF \
+        -DEXIV2_ENABLE_VIDEO=OFF \
+        -DEXIV2_ENABLE_BMFF=ON \
+        -DEXIV2_BUILD_SAMPLES=OFF \
+        -DEXIV2_BUILD_EXIV2_COMMAND=OFF \
+        -DEXIV2_BUILD_UNIT_TESTS=OFF \
+        -DEXIV2_BUILD_DOC=OFF \
+        -DEXIV2_TEAM_EXTRA_WARNINGS=OFF
+    cmake --build "${WORK}/build-exiv2" --parallel "$(nproc)"
+    cmake --install "${WORK}/build-exiv2"
+    rm -rf "${WORK}/exiv2-${EXIV2_VERSION}" "${WORK}/build-exiv2" "${WORK}/exiv2.tar.gz"
+    echo "Exiv2 ${EXIV2_VERSION} installed (Android)."
+
+# ── Native builds (for VAPI generation) ──
+# GExiv2's VAPI requires a native build with introspection=enabled,
+# which needs native Expat + Exiv2 libraries of the same version.
+# Native x86_64 builds are fast (no NDK toolchain overhead).
+NATIVE_PREFIX="${WORK}/native-deps"
+mkdir -p "${NATIVE_PREFIX}"
+
+echo "=== Building Expat ${EXPAT_VERSION} (native) ==="
+echo "  Downloading..."
+wget -nv "https://github.com/libexpat/libexpat/releases/download/R_$(echo ${EXPAT_VERSION} | tr . _)/expat-${EXPAT_VERSION}.tar.xz" -O "${WORK}/expat-native.tar.xz"
+tar -xf "${WORK}/expat-native.tar.xz" -C "${WORK}/"
+    cmake -S "${WORK}/expat-${EXPAT_VERSION}" -B "${WORK}/build-expat-native" -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="${NATIVE_PREFIX}" \
+        -DEXPAT_BUILD_TOOLS=OFF \
+        -DEXPAT_BUILD_EXAMPLES=OFF \
+        -DEXPAT_BUILD_TESTS=OFF \
+        -DEXPAT_BUILD_DOCS=OFF \
+        -DEXPAT_SHARED_LIBS=ON
+    cmake --build "${WORK}/build-expat-native" --parallel "$(nproc)"
+    cmake --install "${WORK}/build-expat-native"
+    rm -rf "${WORK}/expat-${EXPAT_VERSION}" "${WORK}/build-expat-native" "${WORK}/expat-native.tar.xz"
+    echo "Expat ${EXPAT_VERSION} installed (native)."
+
+echo "=== Building Exiv2 ${EXIV2_VERSION} (native) ==="
+echo "  Downloading..."
+wget -nv "https://github.com/Exiv2/exiv2/archive/refs/tags/v${EXIV2_VERSION}.tar.gz" -O "${WORK}/exiv2-native.tar.gz"
+echo "  Extracting..."
+tar -xf "${WORK}/exiv2-native.tar.gz" -C "${WORK}/"
+    cmake -S "${WORK}/exiv2-${EXIV2_VERSION}" -B "${WORK}/build-exiv2-native" -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="${NATIVE_PREFIX}" \
+        -DCMAKE_PREFIX_PATH="${NATIVE_PREFIX}" \
+        -DBUILD_SHARED_LIBS=ON \
+        -DEXIV2_ENABLE_XMP=ON \
+        -DEXIV2_ENABLE_PNG=ON \
+        -DEXIV2_ENABLE_NLS=OFF \
+        -DEXIV2_ENABLE_BROTLI=OFF \
+        -DEXIV2_ENABLE_INIH=OFF \
+        -DEXIV2_ENABLE_WEBREADY=OFF \
+        -DEXIV2_ENABLE_CURL=OFF \
+        -DEXIV2_ENABLE_VIDEO=OFF \
+        -DEXIV2_ENABLE_BMFF=ON \
+        -DEXIV2_BUILD_SAMPLES=OFF \
+        -DEXIV2_BUILD_EXIV2_COMMAND=OFF \
+        -DEXIV2_BUILD_UNIT_TESTS=OFF \
+        -DEXIV2_BUILD_DOC=OFF \
+        -DEXIV2_TEAM_EXTRA_WARNINGS=OFF
+    cmake --build "${WORK}/build-exiv2-native" --parallel "$(nproc)"
+    cmake --install "${WORK}/build-exiv2-native"
+    rm -rf "${WORK}/exiv2-${EXIV2_VERSION}" "${WORK}/build-exiv2-native" "${WORK}/exiv2-native.tar.gz"
+    echo "Exiv2 ${EXIV2_VERSION} installed (native)."
+
+echo "=== Building GExiv2 ${GEXIV2_VERSION} ==="
+if [ ! -f "${PREFIX}/lib/pkgconfig/gexiv2.pc" ]; then
+    echo "  Downloading..."
+    wget -nv "https://download.gnome.org/sources/gexiv2/${GEXIV2_VERSION%.*}/gexiv2-${GEXIV2_VERSION}.tar.xz" -O "${WORK}/gexiv2.tar.xz"
+    echo "  Extracting..."
+    tar -xf "${WORK}/gexiv2.tar.xz" -C "${WORK}/"
+
+    SRC="${WORK}/gexiv2-${GEXIV2_VERSION}"
+
+    # Step 1: Native build (x86_64) to generate the VAPI file.
+    # Uses the same Exiv2/Expat version via the native prefix for VAPI accuracy.
+    echo "  Building natively for VAPI..."
+    PKG_CONFIG_PATH="${NATIVE_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
+    meson setup "${WORK}/build-gexiv2-native" "${SRC}" \
+        --prefix "${WORK}/native-install" \
+        -Dintrospection=true \
+        -Dvapi=true \
+        -Dgtk_doc=false \
+        -Dtests=false \
+        -Dtools=false
+    meson compile -C "${WORK}/build-gexiv2-native"
+    meson install -C "${WORK}/build-gexiv2-native"
+
+    # Copy the generated VAPI for valac to find during cross-compilation
+    mkdir -p "${PREFIX}/share/vala/vapi"
+    cp "${WORK}/native-install/share/vala/vapi/"*.vapi "${PREFIX}/share/vala/vapi/" 2>/dev/null || true
+    cp "${WORK}/native-install/share/vala/vapi/"*.deps "${PREFIX}/share/vala/vapi/" 2>/dev/null || true
+
+    # Step 2: Cross-compile for Android (no introspection/VAPI needed)
+    echo "  Cross-compiling for Android..."
+    cat > "${WORK}/cross-gexiv2.txt" << CROSSEOF
+[constants]
+ndk = '${NDK}'
+
+[binaries]
+c = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${API}-clang'
+cpp = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${API}-clang++'
+ar = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
+strip = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip'
+pkgconfig = 'pkg-config'
+cmake = 'cmake'
+
+[built-in options]
+c_args = ['-DANDROID', '-D__ANDROID_API__=${API}']
+cpp_args = ['-DANDROID', '-D__ANDROID_API__=${API}']
+
+[host_machine]
+system = 'android'
+cpu_family = 'aarch64'
+cpu = 'armv8'
+endian = 'little'
+
+[properties]
+pkg_config_libdir = '${PREFIX}/lib/pkgconfig'
+sys_root = '${PREFIX}'
+CROSSEOF
+
+    # Native file: override build-machine tools so meson finds x86_64 binaries
+    # for code generation (glib-mkenums, etc.) instead of aarch64 ones from $PREFIX.
+    cat > "${WORK}/native-file.txt" << NATIVEEOF
+[binaries]
+glib-mkenums = '/usr/bin/glib-mkenums'
+NATIVEEOF
+
+    export PKG_CONFIG_LIBDIR_FOR_BUILD=""
+    unset PKG_CONFIG_LIBDIR
+    unset PKG_CONFIG_SYSROOT_DIR
+
+    meson setup "${WORK}/build-gexiv2" "${SRC}" \
+        --cross-file "${WORK}/cross-gexiv2.txt" \
+        --native-file "${WORK}/native-file.txt" \
+        --cross-file "${WORK}/cross-gexiv2.txt" \
+        --prefix "${PREFIX}" \
+        -Dintrospection=false \
+        -Dvapi=false \
+        -Dpython3=false \
+        -Dgtk_doc=false \
+        -Dtests=false \
+        -Dtools=false
+    meson compile -C "${WORK}/build-gexiv2"
+    meson install -C "${WORK}/build-gexiv2"
+    rm -rf "${SRC}" "${WORK}/build-gexiv2" "${WORK}/build-gexiv2-native" "${WORK}/native-install" "${WORK}/gexiv2.tar.xz"
+    echo "GExiv2 ${GEXIV2_VERSION} installed."
+else
+    echo "GExiv2 already installed, skipping."
+fi
+
+rm -rf "${WORK}"
+echo "=== All dependencies built ==="
+ls -la "${PREFIX}/lib/pkgconfig/"

--- a/android/cross-android-aarch64.txt
+++ b/android/cross-android-aarch64.txt
@@ -1,0 +1,44 @@
+# Meson cross-compilation file for Android aarch64 (arm64-v8a)
+#
+# Usage:
+#   meson setup build-android --cross-file android/cross-android-aarch64.txt \
+#     -Dgui=enabled -Dgst=enabled -Dgir=disabled -Dmanpages=disabled -Ddocs=disabled
+#
+# Prerequisites:
+#   - Android NDK r26+ installed
+#   - GStreamer for Android pre-built via Cerbero (pkg-config path set below)
+#   - Exiv2 + GExiv2 cross-compiled for Android (pkg-config path set below)
+#   - GTK4 + LibAdwaita for Android (built by pixiewood or manually)
+
+[constants]
+ndk = '/home/user/Android/Sdk/ndk/27.2.12479018'
+# Android API level to target (34 = Android 14)
+api_level = 34
+
+[binaries]
+c = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android' + api_level.to_string() + '-clang'
+cpp = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android' + api_level.to_string() + '-clang++'
+ar = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
+strip = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip'
+pkgconfig = 'pkg-config'
+
+[built-in options]
+c_args = ['-DANDROID', '-D__ANDROID_API__=' + api_level.to_string()]
+cpp_args = ['-DANDROID', '-D__ANDROID_API__=' + api_level.to_string()]
+c_link_args = ['-landroid', '-llog']
+
+[host_machine]
+system = 'android'
+cpu_family = 'aarch64'
+cpu = 'armv8'
+endian = 'little'
+
+[properties]
+# Point these to your pre-built Android dependencies' pkg-config directories.
+# Typically: <prefix>/lib/pkgconfig where <prefix> is where GTK, GStreamer,
+# and Exiv2/GExiv2 were installed for Android.
+#
+# When using pixiewood, it manages these paths automatically.
+# For manual builds, set these to your Android dependency install prefix.
+# pkg_config_libdir = '/path/to/android-deps/lib/pkgconfig'
+# sys_root = '/path/to/android-deps'

--- a/android/cross-android-x86_64.txt
+++ b/android/cross-android-x86_64.txt
@@ -1,0 +1,28 @@
+# Meson cross-compilation file for Android x86_64 (for emulator use)
+#
+# Usage: same as aarch64 variant, just use this cross file instead.
+
+[constants]
+ndk = '/home/user/Android/Sdk/ndk/27.2.12479018'
+api_level = 34
+
+[binaries]
+c = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android' + api_level.to_string() + '-clang'
+cpp = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android' + api_level.to_string() + '-clang++'
+ar = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
+strip = ndk / 'toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip'
+pkgconfig = 'pkg-config'
+
+[built-in options]
+c_args = ['-DANDROID', '-D__ANDROID_API__=' + api_level.to_string()]
+cpp_args = ['-DANDROID', '-D__ANDROID_API__=' + api_level.to_string()]
+c_link_args = ['-landroid', '-llog']
+
+[host_machine]
+system = 'android'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[properties]
+# See android/cross-android-aarch64.txt for property documentation.

--- a/meson.build
+++ b/meson.build
@@ -68,20 +68,11 @@ require_gst = get_option('gst')
 if is_android
   require_gst = true
 endif
-# On Android, GStreamer comes from a subproject whose root does not
-# override standard dependency names until CI patches it. Use
-# required:false during the initial configure to avoid errors;
-# CI reconfigures after patching, at which point the dependencies
-# are found and with_gst becomes true.
-if is_android
-  gst = dependency('gstreamer-1.0', required: false)
-  gst_app = dependency('gstreamer-app-1.0', required: false)
-  gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: false)
-else
-  gst = dependency('gstreamer-1.0', required: require_gst)
-  gst_app = dependency('gstreamer-app-1.0', required: require_gst)
-  gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: require_gst)
-endif
+gst = dependency('gstreamer-1.0', required: require_gst,
+  fallback: ['gstreamer', 'gst_dep'])
+gst_app = dependency('gstreamer-app-1.0', required: require_gst,
+  fallback: ['gst-plugins-base', 'app_dep'])
+gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: require_gst)
 
 # Optional GTK4/LibAdwaita GUI dependencies
 # On Android, the GUI is the only supported interface — require it

--- a/meson.build
+++ b/meson.build
@@ -37,12 +37,11 @@ if is_android
   ])
 
   # GExiv2 — introspection/vapi are disabled for cross-compilation.
+  # Only pass options known to exist in both 0.14.x and 0.16.x.
   gexiv2_proj = subproject('gexiv2', default_options: [
       'introspection=false',
       'vapi=false',
       'tests=false',
-      'tools=false',
-      'python3=false',
       'gtk_doc=false',
   ])
   meson.override_dependency('gexiv2', gexiv2_proj.get_variable('libgexiv2'))

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,38 @@ if is_android
   add_project_arguments('-D', 'ANDROID', language: 'vala')
 endif
 
+# Android: resolve extra dependencies via subprojects to ensure
+# a single shared GLib across gexiv2, gstreamer and the app.
+# This avoids the fatal "two GLib instances" runtime crash.
+if is_android
+  # Exiv2 (needed by gexiv2). Exiv2 already overrides its own dependency name.
+  subproject('exiv2', default_options: [
+      'app=disabled',
+      'tests=disabled',
+      'unitTests=disabled',
+      'webready=disabled',
+      'curl=disabled',
+      'brotli=disabled',
+      'nls=disabled',
+      'bmff=enabled',
+  ])
+
+  # GExiv2 — introspection/vapi are disabled for cross-compilation.
+  gexiv2_proj = subproject('gexiv2', default_options: [
+      'introspection=false',
+      'vapi=false',
+      'tests=false',
+      'tools=false',
+      'python3=false',
+      'gtk_doc=false',
+  ])
+  meson.override_dependency('gexiv2', gexiv2_proj.get_variable('libgexiv2'))
+
+  # Make sure Vala can find the pre-generated VAPI for gexiv2.
+  vapi_dir = meson.project_source_root() / 'vapi'
+  add_project_arguments('--vapidir', vapi_dir, language: 'vala')
+endif
+
 # Dependencies
 basic_deps = [
   dependency('glib-2.0'),
@@ -37,9 +69,14 @@ require_gst = get_option('gst')
 if is_android
   require_gst = true
 endif
-gst = dependency('gstreamer-1.0', required: require_gst)
-gst_app = dependency('gstreamer-app-1.0', required: require_gst)
-gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: require_gst)
+# On Android, GStreamer is resolved via subproject but the monorepo root
+# does not expose gst_dep / override standard names until we patch it.
+# We therefore do NOT require it at configure-time on Android; the CI
+# patches the subproject and reconfigures before building.
+gst_required = require_gst and not is_android
+gst = dependency('gstreamer-1.0', required: gst_required)
+gst_app = dependency('gstreamer-app-1.0', required: gst_required)
+gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: gst_required)
 
 # Optional GTK4/LibAdwaita GUI dependencies
 # On Android, the GUI is the only supported interface — require it

--- a/meson.build
+++ b/meson.build
@@ -69,14 +69,20 @@ require_gst = get_option('gst')
 if is_android
   require_gst = true
 endif
-# On Android, GStreamer is resolved via subproject but the monorepo root
-# does not expose gst_dep / override standard names until we patch it.
-# We therefore do NOT require it at configure-time on Android; the CI
-# patches the subproject and reconfigures before building.
-gst_required = require_gst and not is_android
-gst = dependency('gstreamer-1.0', required: gst_required)
-gst_app = dependency('gstreamer-app-1.0', required: gst_required)
-gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: gst_required)
+# On Android, GStreamer comes from a subproject whose root does not
+# override standard dependency names until CI patches it. Use
+# required:false during the initial configure to avoid errors;
+# CI reconfigures after patching, at which point the dependencies
+# are found and with_gst becomes true.
+if is_android
+  gst = dependency('gstreamer-1.0', required: false)
+  gst_app = dependency('gstreamer-app-1.0', required: false)
+  gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: false)
+else
+  gst = dependency('gstreamer-1.0', required: require_gst)
+  gst_app = dependency('gstreamer-app-1.0', required: require_gst)
+  gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: require_gst)
+endif
 
 # Optional GTK4/LibAdwaita GUI dependencies
 # On Android, the GUI is the only supported interface — require it

--- a/meson.build
+++ b/meson.build
@@ -8,12 +8,16 @@ project('live-photo-conv', ['c', 'vala'],
 lib_api_version = '0.4'  # GIR version / API version
 lib_soversion = '0'      # SONAME version / ABI version
 
-# Windows-specific flags
+# Platform detection
 is_windows = target_machine.system() == 'windows'
 is_darwin = target_machine.system() == 'darwin'
-is_freedesktop = not is_windows and not is_darwin  # Linux, BSD, etc.
+is_android = target_machine.system() == 'android'
+is_freedesktop = not is_windows and not is_darwin and not is_android  # Linux, BSD, etc.
 if is_windows
   add_project_arguments('-D', 'WINDOWS', language: 'vala')
+endif
+if is_android
+  add_project_arguments('-D', 'ANDROID', language: 'vala')
 endif
 
 # Dependencies
@@ -28,16 +32,27 @@ basic_deps = [
 lib_deps = basic_deps
 
 # Optional GStreamer dependencies
+# On Android, GStreamer is required (FFmpeg subprocess not available)
 require_gst = get_option('gst')
+if is_android
+  require_gst = true
+endif
 gst = dependency('gstreamer-1.0', required: require_gst)
 gst_app = dependency('gstreamer-app-1.0', required: require_gst)
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: require_gst)
 
 # Optional GTK4/LibAdwaita GUI dependencies
+# On Android, the GUI is the only supported interface — require it
 require_gui = get_option('gui')
+if is_android
+  require_gui = true
+endif
 gtk4_dep = dependency('gtk4', required: require_gui)
 libadwaita_dep = dependency('libadwaita-1', required: require_gui)
 with_gui = gtk4_dep.found() and libadwaita_dep.found()
+if is_android and not with_gui
+  error('GTK4 and LibAdwaita are required for Android builds')
+endif
 
 with_gst = gst.found() and gst_app.found() and gdk_pixbuf.found()
 if with_gst

--- a/pixiewood.xml
+++ b/pixiewood.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<app xmlns="https://sp1rit.arpa/pixiewood/"
+     xmlns:xi="http://www.w3.org/2001/XInclude">
+  <metainfo vercalc="sem121010">
+    <!--
+      vercalc: sem121010 maps semantic versioning to an Android versionCode
+      via (major << 20) + (minor << 10) + (patch).
+      The app's version info will be read from the Meson project version.
+    -->
+  </metainfo>
+  <style>
+    <!-- Use LibAdwaita theme for the modern GNOME mobile look -->
+    <theme name="adw"/>
+    <icon type="generate">
+      <!-- Adaptive icon: foreground layer from SVG asset -->
+      <drawable target="foreground" scale=".5" type="svg"
+                path="src://android/app-icon-foreground.svg"/>
+      <!-- Background color for the adaptive icon -->
+      <color target="background">#3584e4</color>
+    </icon>
+  </style>
+  <dependencies>
+    <!--
+      pixiewood builds these dependencies from source using Meson
+      subprojects/wrap files. The <patch>hack</patch> on glib applies
+      necessary Android workarounds.
+    -->
+    <glib>
+      <patch>hack</patch>
+    </glib>
+    <cairo/>
+    <fontconfig/>
+    <!-- GTK dependency includes the full stack: pango, harfbuzz, gdk-pixbuf, etc. -->
+    <gtk/>
+    <!--
+      Note: pixiewood does not currently build GStreamer or GExiv2.
+      These must be pre-built for Android and their pkg-config paths
+      added to PKG_CONFIG_LIBDIR before running pixiewood prepare.
+      See android/README.md for instructions.
+    -->
+  </dependencies>
+  <build target="live-photo-conv-gtk"
+         java-sources="gdk/android/glue/java/">
+    <architectures>
+      <arch>aarch64</arch>
+      <!-- Uncomment for emulator support: -->
+      <!-- <arch>x86_64</arch> -->
+    </architectures>
+    <configure-options>
+      <option>-Dgui=enabled</option>
+      <option>-Dgst=enabled</option>
+      <option>-Dgir=disabled</option>
+      <option>-Dmanpages=disabled</option>
+      <option>-Ddocs=disabled</option>
+    </configure-options>
+  </build>
+</app>

--- a/pixiewood.xml
+++ b/pixiewood.xml
@@ -52,19 +52,8 @@
       <option>-Dgir=disabled</option>
       <option>-Dmanpages=disabled</option>
       <option>-Ddocs=disabled</option>
-      <!-- Force GStreamer subproject on Android (shared GLib) -->
-      <option>--force-fallback-for=gstreamer</option>
-      <!-- GStreamer minimal build: only core + app + playback -->
-      <option>-Dgstreamer:base=enabled</option>
-      <option>-Dgstreamer:good=disabled</option>
-      <option>-Dgstreamer:bad=disabled</option>
-      <option>-Dgstreamer:ugly=disabled</option>
-      <option>-Dgstreamer:libav=disabled</option>
-      <option>-Dgstreamer:tests=disabled</option>
-      <option>-Dgstreamer:examples=disabled</option>
-      <option>-Dgstreamer:introspection=disabled</option>
-      <option>-Dgstreamer:doc=disabled</option>
-      <option>-Dgstreamer:tools=disabled</option>
+      <!-- Force GStreamer subprojects on Android (shared GLib) -->
+      <option>--force-fallback-for=gstreamer,gst-plugins-base</option>
     </configure-options>
   </build>
 </app>

--- a/pixiewood.xml
+++ b/pixiewood.xml
@@ -33,10 +33,10 @@
     <!-- GTK dependency includes the full stack: pango, harfbuzz, gdk-pixbuf, etc. -->
     <gtk/>
     <!--
-      Note: pixiewood does not currently build GStreamer or GExiv2.
-      These must be pre-built for Android and their pkg-config paths
-      added to PKG_CONFIG_LIBDIR before running pixiewood prepare.
-      See android/README.md for instructions.
+      GStreamer and the GExiv2/Exiv2 chain are now resolved via Meson
+      subprojects/wrap files (see subprojects/*.wrap). They are built
+      from source by pixiewood, sharing the same GLib subproject to
+      avoid the fatal "two GLib instances" runtime crash.
     -->
   </dependencies>
   <build target="live-photo-conv-gtk"
@@ -52,6 +52,19 @@
       <option>-Dgir=disabled</option>
       <option>-Dmanpages=disabled</option>
       <option>-Ddocs=disabled</option>
+      <!-- Force GStreamer subproject on Android (shared GLib) -->
+      <option>--force-fallback-for=gstreamer</option>
+      <!-- GStreamer minimal build: only core + app + playback -->
+      <option>-Dgstreamer:base=enabled</option>
+      <option>-Dgstreamer:good=disabled</option>
+      <option>-Dgstreamer:bad=disabled</option>
+      <option>-Dgstreamer:ugly=disabled</option>
+      <option>-Dgstreamer:libav=disabled</option>
+      <option>-Dgstreamer:tests=disabled</option>
+      <option>-Dgstreamer:examples=disabled</option>
+      <option>-Dgstreamer:introspection=disabled</option>
+      <option>-Dgstreamer:doc=disabled</option>
+      <option>-Dgstreamer:tools=disabled</option>
     </configure-options>
   </build>
 </app>

--- a/src/meson.build
+++ b/src/meson.build
@@ -87,28 +87,31 @@ pkg.generate(
   requires: lib_deps,
 )
 
-# Build only the main executable once
-main_exe_name = 'live-photo-conv'
-main_exe_bin = executable(main_exe_name,
-  ['main.vala'],
-  install: true,
-  link_with: liblivephototools,
-  dependencies: lib_deps,
-  #include_directories: incdir,
-)
+# CLI executables — not built on Android (GUI-only)
+if not is_android
+  # Build only the main executable once
+  main_exe_name = 'live-photo-conv'
+  main_exe_bin = executable(main_exe_name,
+    ['main.vala'],
+    install: true,
+    link_with: liblivephototools,
+    dependencies: lib_deps,
+    #include_directories: incdir,
+  )
 
-# Sub executable names that should be links/copies of the main binary
-sub_exe_names = ['live-photo-make', 'live-photo-extract', 'live-photo-repair']
+  # Sub executable names that should be links/copies of the main binary
+  sub_exe_names = ['live-photo-make', 'live-photo-extract', 'live-photo-repair']
 
-# Build copy-img-meta separately as it has different sources
-copy_img_meta_name = 'copy-img-meta'
-copy_img_meta_bin = executable(copy_img_meta_name,
-  ['copyimgmeta.vala'],
-  install: true,
-  link_with: liblivephototools,
-  dependencies: lib_deps,
-  #include_directories: incdir,
-)
+  # Build copy-img-meta separately as it has different sources
+  copy_img_meta_name = 'copy-img-meta'
+  copy_img_meta_bin = executable(copy_img_meta_name,
+    ['copyimgmeta.vala'],
+    install: true,
+    link_with: liblivephototools,
+    dependencies: lib_deps,
+    #include_directories: incdir,
+  )
+endif
 
 # Build GTK4/LibAdwaita GUI
 gui_name = 'live-photo-conv-gtk'
@@ -116,7 +119,7 @@ gui_sources = ['gui.vala']
 if with_gui
   gui_deps = lib_deps + [gtk4_dep, libadwaita_dep]
 
-  # Embed application icons via GResource on non-Linux
+  # Embed application icons via GResource on non-Linux (Android, Windows, macOS)
   if not is_freedesktop
     gui_sources += gnome.compile_resources('live-photo-conv-gtk-resources',
       'icons.gresource.xml',
@@ -139,13 +142,35 @@ if with_gui
     gui_sources += import('windows').compile_resources(win_rc)
   endif
 
-  executable(gui_name,
-    gui_sources,
-    install: true,
-    link_with: liblivephototools,
-    dependencies: gui_deps,
-    win_subsystem: 'windows',
-  )
+  if is_android
+    # On Android, the GUI is built as a shared library (.so).
+    # GTK's Android runtime (libgtk-4.so) dlopens it and calls main().
+    # Meson >= 1.9 provides 'android_exe_type' kwarg for this.
+    if meson.version().version_compare('>= 1.9.0')
+      gui_exe = executable(gui_name,
+        gui_sources,
+        install: true,
+        link_with: liblivephototools,
+        dependencies: gui_deps,
+        android_exe_type: 'application',
+      )
+    else
+      gui_exe = shared_library(gui_name,
+        gui_sources,
+        install: true,
+        link_with: liblivephototools,
+        dependencies: gui_deps,
+      )
+    endif
+  else
+    executable(gui_name,
+      gui_sources,
+      install: true,
+      link_with: liblivephototools,
+      dependencies: gui_deps,
+      win_subsystem: 'windows',
+    )
+  endif
 
   if is_freedesktop
     # Install desktop file and hicolor icon (freedesktop / Linux)
@@ -159,37 +184,39 @@ if with_gui
   endif
 endif
 
-# Create symlinks/copies in build directory and install them
-symlink_script = meson.project_source_root() / 'scripts' / 'create-binary-symlinks.py'
-sub_exe_bins = []
-foreach exe_name : sub_exe_names
-  # Create link/copy in build directory and install it
-  linked_exe = custom_target('link-' + exe_name,
-    output: exe_name + (is_windows ? '.exe' : ''),
-    command: [
-      python,
-      symlink_script,
-      main_exe_bin.full_path(),
-      '@OUTPUT@',
-    ],
-    depends: main_exe_bin,
-    build_by_default: true,
-    install: is_windows, # Workaround for https://github.com/mesonbuild/meson/issues/12710
-    install_dir: get_option('bindir'),
-  )
-  # Workaround for https://github.com/mesonbuild/meson/issues/12710
-  if not is_windows
-    install_symlink(
-      exe_name,
-      pointing_to: main_exe_name,
-      install_dir: get_option('bindir')
+# Create symlinks/copies in build directory and install them (desktop CLI only)
+if not is_android
+  symlink_script = meson.project_source_root() / 'scripts' / 'create-binary-symlinks.py'
+  sub_exe_bins = []
+  foreach exe_name : sub_exe_names
+    # Create link/copy in build directory and install it
+    linked_exe = custom_target('link-' + exe_name,
+      output: exe_name + (is_windows ? '.exe' : ''),
+      command: [
+        python,
+        symlink_script,
+        main_exe_bin.full_path(),
+        '@OUTPUT@',
+      ],
+      depends: main_exe_bin,
+      build_by_default: true,
+      install: is_windows, # Workaround for https://github.com/mesonbuild/meson/issues/12710
+      install_dir: get_option('bindir'),
     )
-  endif
+    # Workaround for https://github.com/mesonbuild/meson/issues/12710
+    if not is_windows
+      install_symlink(
+        exe_name,
+        pointing_to: main_exe_name,
+        install_dir: get_option('bindir')
+      )
+    endif
 
-  sub_exe_bins += [linked_exe]
-endforeach
+    sub_exe_bins += [linked_exe]
+  endforeach
+endif
 
-if help2man_prog.found()
+if not is_android and help2man_prog.found()
   # Generate manpage for main executable
   custom_target('manpage-' + main_exe_name,
     output : main_exe_name + '.1',

--- a/subprojects/exiv2.wrap
+++ b/subprojects/exiv2.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = exiv2-0.28.8
+source_url = https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.8.tar.gz
+source_filename = exiv2-0.28.8.tar.gz
+source_hash = ea51b0609f58a9afa063b60daa1539948b62247721e154f4fff0ad3aec9f9756
+
+[provide]
+dependency_names = exiv2

--- a/subprojects/gexiv2.wrap
+++ b/subprojects/gexiv2.wrap
@@ -1,8 +1,0 @@
-[wrap-file]
-directory = gexiv2-0.16.0
-source_url = https://download.gnome.org/sources/gexiv2/0.16/gexiv2-0.16.0.tar.xz
-source_filename = gexiv2-0.16.0.tar.xz
-source_hash = d96f895f24539f966f577b2bb2489ae84f8232970a8d0c064e4a007474a77bbb
-
-[provide]
-dependency_names = gexiv2

--- a/subprojects/gexiv2.wrap
+++ b/subprojects/gexiv2.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = gexiv2-0.16.0
+source_url = https://download.gnome.org/sources/gexiv2/0.16/gexiv2-0.16.0.tar.xz
+source_filename = gexiv2-0.16.0.tar.xz
+source_hash = d96f895f24539f966f577b2bb2489ae84f8232970a8d0c064e4a007474a77bbb
+
+[provide]
+dependency_names = gexiv2

--- a/subprojects/gst-plugins-base.wrap
+++ b/subprojects/gst-plugins-base.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = gst-plugins-base-1.28.2
+source_url = https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.28.2.tar.xz
+source_filename = gst-plugins-base-1.28.2.tar.xz
+source_hash = 4db76b3619280037a4047de7d9dbb38613a4272dcc40efb333257124635a888d
+
+[provide]
+dependency_names = gstreamer-app-1.0, gstreamer-video-1.0, gstreamer-pbutils-1.0, gstreamer-audio-1.0, gstreamer-rtp-1.0, gstreamer-tag-1.0

--- a/subprojects/gstreamer.wrap
+++ b/subprojects/gstreamer.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+directory = gstreamer
+url = https://gitlab.freedesktop.org/gstreamer/gstreamer.git
+revision = 1.28.2
+depth = 1
+
+[provide]
+dependency_names = gstreamer-1.0, gstreamer-app-1.0, gstreamer-video-1.0, gstreamer-pbutils-1.0, gstreamer-audio-1.0

--- a/subprojects/gstreamer.wrap
+++ b/subprojects/gstreamer.wrap
@@ -1,8 +1,8 @@
-[wrap-git]
-directory = gstreamer
-url = https://gitlab.freedesktop.org/gstreamer/gstreamer.git
-revision = 1.28.2
-depth = 1
+[wrap-file]
+directory = gstreamer-1.28.2
+source_url = https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.28.2.tar.xz
+source_filename = gstreamer-1.28.2.tar.xz
+source_hash = ce5cd44d4ffeafdcc3dddaa072b2179c0b7cb1abf4e6c5d18d4375f8a39fe491
 
 [provide]
-dependency_names = gstreamer-1.0, gstreamer-app-1.0, gstreamer-video-1.0, gstreamer-pbutils-1.0, gstreamer-audio-1.0
+dependency_names = gstreamer-1.0, gstreamer-base-1.0, gstreamer-controller-1.0, gstreamer-net-1.0, gstreamer-check-1.0

--- a/vapi/.gitkeep
+++ b/vapi/.gitkeep
@@ -1,0 +1,3 @@
+# This directory holds pre-generated VAPI files for Android cross-compilation.
+# GExiv2's VAPI is generated in CI via a host build because GObject
+# Introspection cannot run during cross-compilation.


### PR DESCRIPTION
- Add `build-android` job to CI workflow (`.github/workflows/ci.yml`) targeting aarch64 on ubuntu-24.04.
- Implement cross-compilation script (`android/build-exiv2-android.sh`) for Expat, Exiv2, and GExiv2.
- Introduce Meson cross-compilation files (`android/cross-android-*.txt`) for aarch64 and x86_64.
- Configure `pixiewood.xml` to build the GTK4/LibAdwaita GUI as an Android application.
- Update `meson.build` to detect Android target, enforce GUI/GStreamer requirements, and build the GUI as a shared library (`.so`) instead of a standalone executable.
- Skip CLI tool builds on Android as the platform is GUI-only.
- Add adaptive app icon (`android/app-icon-foreground.svg`) and integrate it into the pixiewood configuration.
- Update release workflow to include Android APK artifacts.