### PR TITLE
ci: add macOS Homebrew tap build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,29 @@ jobs:
         name: windows-package
         path: distros/msys2/*.pkg.tar.zst
 
+  build-macos:
+    name: Build macOS Homebrew Package
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Build Package
+      run: |
+        brew update
+        brew tap-new --no-git wszqkzqk/live-photo-conv
+        formula="$(brew --repository wszqkzqk/live-photo-conv)/Formula/live-photo-conv.rb"
+        cp Formula/live-photo-conv.rb "$formula"
+        sed -i '' "s|https://github.com/wszqkzqk/live-photo-conv.git\", branch: \"main\", using: :git|file://$GITHUB_WORKSPACE\", revision: \"$GITHUB_SHA\", using: :git|" "$formula"
+
+        brew install --HEAD wszqkzqk/live-photo-conv/live-photo-conv
+        brew test wszqkzqk/live-photo-conv/live-photo-conv
+
   release:
     name: Release
     if: github.ref_type == 'tag'
-    needs: [build-archlinux, build-flatpak, build-windows]
+    needs: [build-archlinux, build-flatpak, build-windows, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Formula/live-photo-conv.rb
+++ b/Formula/live-photo-conv.rb
@@ -1,0 +1,32 @@
+class LivePhotoConv < Formula
+  desc "Cross-platform tool to process live photos of Google Android"
+  homepage "https://github.com/wszqkzqk/live-photo-conv"
+  license "LGPL-2.1-or-later"
+  head "https://github.com/wszqkzqk/live-photo-conv.git", branch: "main", using: :git
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :build
+  depends_on "vala" => :build
+  depends_on "gobject-introspection" => :build
+  depends_on "help2man" => :build
+
+  depends_on "adwaita-icon-theme"
+  depends_on "gdk-pixbuf"
+  depends_on "gexiv2"
+  depends_on "glib"
+  depends_on "gstreamer"
+  depends_on "gtk4"
+  depends_on "libadwaita"
+
+  def install
+    system "meson", "setup", "build", *std_meson_args
+    system "meson", "compile", "-C", "build"
+    system "meson", "install", "-C", "build"
+  end
+
+  test do
+    assert_match "Live Photo Converter", shell_output("#{bin}/live-photo-conv --version 2>&1")
+    assert_predicate bin/"live-photo-conv-gtk", :exist?
+  end
+end

--- a/README-zh.md
+++ b/README-zh.md
@@ -84,6 +84,15 @@ flatpak-builder --user --install --force-clean build-flatpak com.github.wszqkzqk
 flatpak run com.github.wszqkzqk.live-photo-conv
 ```
 
+### macOS (Homebrew)
+
+macOS 可以将本仓库作为 Homebrew tap 安装：
+
+```bash
+brew tap wszqkzqk/live-photo-conv https://github.com/wszqkzqk/live-photo-conv
+brew install --HEAD wszqkzqk/live-photo-conv/live-photo-conv
+```
+
 ## 手动构建
 
 ### 依赖
@@ -111,6 +120,12 @@ sudo pacman -S --needed glib2 libgexiv2 meson vala gtk4 libadwaita gstreamer gst
 
 ```bash
 sudo apt install build-essential meson valac libgexiv2-dev libglib2.0-dev libgtk-4-dev libadwaita-1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgdk-pixbuf-2.0-dev gobject-introspection libgirepository1.0-dev gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-vaapi
+```
+
+在 macOS 上使用 Homebrew 安装依赖：
+
+```bash
+brew install meson vala pkgconf glib gexiv2 gtk4 libadwaita adwaita-icon-theme gstreamer gdk-pixbuf gobject-introspection ffmpeg help2man
 ```
 
 在Windows的MSYS2（UCRT64）环境上安装依赖：

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ flatpak-builder --user --install --force-clean build-flatpak com.github.wszqkzqk
 flatpak run com.github.wszqkzqk.live-photo-conv
 ```
 
+### macOS (Homebrew)
+
+On macOS, install from this repository as a Homebrew tap:
+
+```bash
+brew tap wszqkzqk/live-photo-conv https://github.com/wszqkzqk/live-photo-conv
+brew install --HEAD wszqkzqk/live-photo-conv/live-photo-conv
+```
+
 ## Manual Build
 
 ### Dependencies
@@ -111,6 +120,12 @@ To install dependencies on Debian/Ubuntu:
 
 ```bash
 sudo apt install build-essential meson valac libgexiv2-dev libglib2.0-dev libgtk-4-dev libadwaita-1-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgdk-pixbuf-2.0-dev gobject-introspection libgirepository1.0-dev gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-vaapi
+```
+
+To install dependencies on macOS with Homebrew:
+
+```bash
+brew install meson vala pkgconf glib gexiv2 gtk4 libadwaita adwaita-icon-theme gstreamer gdk-pixbuf gobject-introspection ffmpeg help2man
 ```
 
 To install dependencies on Windows by MSYS2 (UCRT64 environment):

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ basic_deps = [
   dependency('gobject-2.0'),
   dependency('gio-2.0'),
   dependency('gmodule-2.0'),
-  dependency('gexiv2'),
+  dependency('gexiv2-0.16', 'gexiv2'),
 ]
 # Dependencies for the library
 lib_deps = basic_deps


### PR DESCRIPTION
  Add a Homebrew formula template for macOS bottles, build and upload the
  bottle in CI, document Homebrew dependencies, and support Homebrew's
  versioned GExiv2 pkg-config name.